### PR TITLE
IMDb get user id from user profile - refs #119

### DIFF
--- a/RatS/imdb/imdb_ratings_parser.py
+++ b/RatS/imdb/imdb_ratings_parser.py
@@ -12,7 +12,8 @@ class IMDBRatingsParser(RatingsDownloader):
         self.downloaded_file_name = 'ratings.csv'
 
     def _get_user_id(self):
-        return self.site.browser.find_element_by_id('main').get_attribute('data-userid')
+        self.site.browser.get('https://www.imdb.com/profile')
+        return self.site.browser.find_elements_by_xpath('//div[@data-userid]')[0].get_attribute('data-userid')
 
     def _parse_ratings(self):
         self._download_ratings_csv()


### PR DESCRIPTION
### Description of the Change
The div with id main has been removed. The user id is not present in the IMDb landing page, it is located in the user profile.
Fix #119 