### PR TITLE
[WIP] Refactor: use type hinting #170

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: python:3.9 # change to match your python version
+image: python:3.10 # change to match your python version
 
 stages:
   - test

--- a/.idea/RatS.iml
+++ b/.idea/RatS.iml
@@ -5,7 +5,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.10 (RatS)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/RatS/allocine/allocine_ratings_inserter.py
+++ b/RatS/allocine/allocine_ratings_inserter.py
@@ -25,7 +25,7 @@ class AlloCineRatingsInserter(RatingsInserter):
         return search_result_page.find_all("div", class_="entity-card")
 
     def _is_requested_movie(self, movie: Movie, search_result):
-        if self._is_field_in_parsed_data_for_this_site(movie, "id"):
+        if self._is_id_in_parsed_data_for_this_site(movie):
             return movie.site_data[self.site.site].id == search_result["data-movie-id"]
         else:
             return self._check_movie_details(movie, search_result)

--- a/RatS/allocine/allocine_ratings_parser.py
+++ b/RatS/allocine/allocine_ratings_parser.py
@@ -75,6 +75,7 @@ class AlloCineRatingsParser(RatingsParser):
         while rating == 0:
             iteration += 1
             if iteration > 10:
+                # overwrite pass-by-reference variable to ignore this movie
                 movie = None
                 return
             movie_details_page = BeautifulSoup(

--- a/RatS/allocine/allocine_ratings_parser.py
+++ b/RatS/allocine/allocine_ratings_parser.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 
 from RatS.base.base_ratings_parser import RatingsParser
 from RatS.allocine.allocine_site import AlloCine
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData
 
 
 class AlloCineRatingsParser(RatingsParser):

--- a/RatS/allocine/allocine_ratings_parser.py
+++ b/RatS/allocine/allocine_ratings_parser.py
@@ -10,7 +10,7 @@ class AlloCineRatingsParser(RatingsParser):
     def __init__(self, args):
         super(AlloCineRatingsParser, self).__init__(AlloCine(args), args)
 
-    def _get_ratings_page(self, page_number):
+    def _get_ratings_page(self, page_number: int):
         return f"{self.site.MY_RATINGS_URL}?page={page_number}"
 
     def _retrieve_pages_count_and_movies_count(self, movie_ratings_page):
@@ -67,7 +67,7 @@ class AlloCineRatingsParser(RatingsParser):
         movie_path = movie_tile.find("a", class_="meta-title-link")["href"]
         return f"https://www.allocine.fr{movie_path}"
 
-    def parse_movie_details_page(self, movie):
+    def parse_movie_details_page(self, movie: Movie):
         rating = 0
         iteration = 0
         movie_details_page = None
@@ -81,11 +81,11 @@ class AlloCineRatingsParser(RatingsParser):
             )
             rating = self._get_movie_my_rating(movie_details_page)
 
-        movie["year"] = self._get_movie_year(movie_details_page)
-        movie["title"] = self._get_movie_original_title(movie_details_page)
-        if self.site.site_name.lower() not in movie:
-            movie[self.site.site_name.lower()] = dict()
-        movie[self.site.site_name.lower()]["my_rating"] = rating
+        movie.year = self._get_movie_year(movie_details_page)
+        movie.title = self._get_movie_original_title(movie_details_page)
+        if self.site.site not in movie.site_data:
+            movie.site_data[self.site.site] = SiteSpecificMovieData()
+        movie.site_data[self.site.site].my_rating = rating
 
     @staticmethod
     def _get_movie_year(movie_details_page):

--- a/RatS/allocine/allocine_site.py
+++ b/RatS/allocine/allocine_site.py
@@ -3,10 +3,10 @@ import time
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
-from RatS.base.base_site import Site
+from RatS.base.base_site import BaseSite
 
 
-class AlloCine(Site):
+class AlloCine(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form[@name='sign_in']"
         self.LOGIN_USERNAME_SELECTOR = (

--- a/RatS/base/base_exceptions.py
+++ b/RatS/base/base_exceptions.py
@@ -21,5 +21,6 @@ class NoValidCredentialsException(RatSException):
 class SiteNotReachableException(RatSException):
     pass
 
+
 class NoMoviesForInsertion(LoginFailedException):
     pass

--- a/RatS/base/base_exceptions.py
+++ b/RatS/base/base_exceptions.py
@@ -20,3 +20,6 @@ class NoValidCredentialsException(RatSException):
 
 class SiteNotReachableException(RatSException):
     pass
+
+class NoMoviesForInsertion(LoginFailedException):
+    pass

--- a/RatS/base/base_exceptions.py
+++ b/RatS/base/base_exceptions.py
@@ -1,0 +1,22 @@
+class RatSException(Exception):
+    pass
+
+
+class LoginFailedException(RatSException):
+    pass
+
+
+class CaptchaPresentException(LoginFailedException):
+    pass
+
+
+class CSVDownloadFailedException(RatSException):
+    pass
+
+
+class NoValidCredentialsException(RatSException):
+    pass
+
+
+class SiteNotReachableException(RatSException):
+    pass

--- a/RatS/base/base_ratings_downloader.py
+++ b/RatS/base/base_ratings_downloader.py
@@ -8,13 +8,14 @@ from selenium.common.exceptions import TimeoutException
 
 from RatS.base.base_exceptions import CSVDownloadFailedException
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.base_site import BaseSite
 from RatS.utils import file_impex
 
 TIMESTAMP = datetime.datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")
 
 
 class RatingsDownloader(RatingsParser):
-    def __init__(self, site, args):
+    def __init__(self, site: BaseSite, args):
         super(RatingsDownloader, self).__init__(site, args)
         self.csv_filename = f"{TIMESTAMP}_{site.site_name}.csv"
         self.csv_delimiter = ","
@@ -74,7 +75,7 @@ class RatingsDownloader(RatingsParser):
             )
             sys.stdout.flush()
 
-    def _parse_movies_from_csv(self, filepath):
+    def _parse_movies_from_csv(self, filepath: str):
         sys.stdout.write("===== getting movies from CSV\r\n")
         sys.stdout.flush()
         file_impex.wait_for_file_to_exist(filepath)

--- a/RatS/base/base_ratings_downloader.py
+++ b/RatS/base/base_ratings_downloader.py
@@ -6,8 +6,8 @@ import datetime
 import os
 from selenium.common.exceptions import TimeoutException
 
+from RatS.base.base_exceptions import CSVDownloadFailedException
 from RatS.base.base_ratings_parser import RatingsParser
-from RatS.base.csv_download_exception import CSVDownloadFailedException
 from RatS.utils import file_impex
 
 TIMESTAMP = datetime.datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")

--- a/RatS/base/base_ratings_inserter.py
+++ b/RatS/base/base_ratings_inserter.py
@@ -58,13 +58,16 @@ class RatingsInserter:
         self._handle_failed_movies()
         self.site.browser_handler.kill()
 
-    def _is_field_in_parsed_data_for_this_site(
-        self, movie: Movie, field: str
-    ):  # TODO check if usage of either id or url is sufficient
+    def _is_id_in_parsed_data_for_this_site(self, movie: Movie):
         return (
             self.site.site in movie.site_data
-            and field in movie.site_data[self.site.site]
-            and movie.site_data[self.site.site][field] != ""
+            and movie.site_data[self.site.site].id != ""
+        )
+
+    def _is_url_in_parsed_data_for_this_site(self, movie: Movie):
+        return (
+            self.site.site in movie.site_data
+            and movie.site_data[self.site.site].url != ""
         )
 
     def print_progress(self, counter: int, movie: Movie, movies: List[Movie]):
@@ -91,7 +94,7 @@ class RatingsInserter:
             self.progress_bar.finish()
 
     def _go_to_movie_details_page(self, movie: Movie):
-        if self._is_field_in_parsed_data_for_this_site(movie, "url"):
+        if self._is_url_in_parsed_data_for_this_site(movie):
             self.site.open_url_with_521_retry(movie.site_data[self.site.site].url)
             success = True
         else:

--- a/RatS/base/base_ratings_parser.py
+++ b/RatS/base/base_ratings_parser.py
@@ -49,8 +49,8 @@ class RatingsParser:
         return self.movies
 
     def _parse_ratings(self):
-        movie_ratings_page = BeautifulSoup(self.site.browser.page_source, "html.parser")
         time.sleep(1)
+        movie_ratings_page = BeautifulSoup(self.site.browser.page_source, "html.parser")
 
         pages_count: int = self._retrieve_pages_count_and_movies_count(
             movie_ratings_page

--- a/RatS/base/base_ratings_parser.py
+++ b/RatS/base/base_ratings_parser.py
@@ -78,7 +78,7 @@ class RatingsParser:
         sys.stdout.flush()
 
         for page_number in range(1, pages_count + 1):
-            self.site.open_url_with_521_retry(self._get_ratings_page(1))
+            self.site.open_url_with_521_retry(self._get_ratings_page(page_number))
             movie_listing_page = BeautifulSoup(
                 self.site.browser.page_source, "html.parser"
             )
@@ -128,9 +128,10 @@ class RatingsParser:
             self.progress_bar = ProgressBar(
                 max_value=self.movies_count, redirect_stdout=True
             )
-        self.progress_bar.update(len(self.movies))
-        if self.movies_count == len(self.movies):
+        if len(self.movies) >= self.movies_count:
             self.progress_bar.finish()
+        else:
+            self.progress_bar.update(len(self.movies))
 
     @staticmethod
     def _get_movie_tiles(movie_listing_page):

--- a/RatS/base/base_ratings_parser.py
+++ b/RatS/base/base_ratings_parser.py
@@ -161,7 +161,7 @@ class RatingsParser:
 
     def _go_to_movie_details_page(self, movie: Movie):
         self.site.open_url_with_521_retry(
-            movie.site_data[self.site.site_name.lower()].url
+            movie.site_data[self.site.site].url
         )
 
     @staticmethod

--- a/RatS/base/base_ratings_uploader.py
+++ b/RatS/base/base_ratings_uploader.py
@@ -3,10 +3,13 @@ import time
 
 import datetime
 import os
+from typing import List
 
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.base_site import BaseSite
+from RatS.base.movie_entity import Site, Movie
 from RatS.base.no_movies_for_insertion import NoMoviesForInsertion
 from RatS.utils.file_impex import save_movies_to_csv
 
@@ -14,9 +17,9 @@ TIMESTAMP = datetime.datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S"
 
 
 class RatingsUploader(RatingsInserter):
-    def __init__(self, site, args):
+    def __init__(self, site: BaseSite, args):
         super(RatingsUploader, self).__init__(site, args)
-        self.csv_filename = TIMESTAMP + "_converted_for_" + site.site_name + ".csv"
+        self.csv_filename = f"{TIMESTAMP}_converted_for_{site.site_name}.csv"
 
     def insert(self, movies, source):
         sys.stdout.write(
@@ -24,8 +27,10 @@ class RatingsUploader(RatingsInserter):
         )
         sys.stdout.flush()
 
-        if self.site.site_name.lower() == "movielens":
-            movies = [movie for movie in movies if "imdb" in movie]
+        if self.site.site == Site.MOVIELENS:
+            movies: List[Movie] = [
+                movie for movie in movies if Site.IMDB in movie.site_data
+            ]
 
         if len(movies) == 0:
             self.site.browser_handler.kill()

--- a/RatS/base/base_ratings_uploader.py
+++ b/RatS/base/base_ratings_uploader.py
@@ -7,10 +7,10 @@ from typing import List
 
 from selenium.webdriver.common.by import By
 
+from RatS.base.base_exceptions import NoMoviesForInsertion
 from RatS.base.base_ratings_inserter import RatingsInserter
 from RatS.base.base_site import BaseSite
 from RatS.base.movie_entity import Site, Movie
-from RatS.base.no_movies_for_insertion import NoMoviesForInsertion
 from RatS.utils.file_impex import save_movies_to_csv
 
 TIMESTAMP = datetime.datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")
@@ -21,7 +21,7 @@ class RatingsUploader(RatingsInserter):
         super(RatingsUploader, self).__init__(site, args)
         self.csv_filename = f"{TIMESTAMP}_converted_for_{site.site_name}.csv"
 
-    def insert(self, movies, source):
+    def insert(self, movies: List[Movie], source: Site):
         sys.stdout.write(
             f"\r===== {self.site.site_displayname}: posting {len(movies)} movies\r\n"
         )

--- a/RatS/base/base_site.py
+++ b/RatS/base/base_site.py
@@ -23,9 +23,9 @@ class BaseSite:
     def __init__(self, args):
         self.args = args
 
-        self.site_name = type(self).__name__
-        self.site = Site.get(self.site_name, None)
-        self.site_displayname = (
+        self.site_name: str = type(self).__name__
+        self.site: Site = Site(self.site_name.upper())
+        self.site_displayname: str = (
             f"{BashColor.HEADER}{BashColor.BOLD}{self.site_name}{BashColor.END}"
             if hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
             else self.site_name
@@ -38,13 +38,13 @@ class BaseSite:
         self.CREDENTIALS_VALID = self._validate_credentials()
 
         if self.CREDENTIALS_VALID:
-            self.LOGIN_PAGE = self._get_login_page_url()
+            self.LOGIN_PAGE: str = self._get_login_page_url()
 
             self._init_browser()
 
             self._parse_configuration()
 
-    def __read_config_file(self, filename):
+    def __read_config_file(self, filename: str):
         self.config.read(
             os.path.abspath(
                 os.path.join(os.path.dirname(__file__), os.pardir, filename)
@@ -53,13 +53,13 @@ class BaseSite:
 
     def _parse_credentials(self):
         if os.environ.get(self.site_name.upper() + "_USERNAME"):
-            self.USERNAME = os.environ.get(self.site_name.upper() + "_USERNAME")
+            self.USERNAME: str = os.environ.get(self.site_name.upper() + "_USERNAME")
         else:
-            self.USERNAME = self.config[self.site_name]["USERNAME"]
+            self.USERNAME: str = self.config[self.site_name]["USERNAME"]
         if os.environ.get(self.site_name.upper() + "_PASSWORD"):
-            self.PASSWORD = os.environ.get(self.site_name.upper() + "_PASSWORD")
+            self.PASSWORD: str = os.environ.get(self.site_name.upper() + "_PASSWORD")
         else:
-            self.PASSWORD = self.config[self.site_name]["PASSWORD"]
+            self.PASSWORD: str = self.config[self.site_name]["PASSWORD"]
 
     def _validate_credentials(self):
         return (
@@ -158,7 +158,7 @@ class BaseSite:
         response = self.browser.find_element(By.TAG_NAME, "pre").text.strip()
         return json.loads(response)
 
-    def open_url_with_521_retry(self, url):
+    def open_url_with_521_retry(self, url: str):
         iteration = 0
         self.browser.get(url)
 

--- a/RatS/base/base_site.py
+++ b/RatS/base/base_site.py
@@ -9,6 +9,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 from RatS.base.login_failed_exception import LoginFailedException
+from RatS.base.movie_entity import Site
 from RatS.base.site_not_reachable_exception import SiteNotReachableException
 from RatS.utils.bash_color import BashColor
 from RatS.utils.browser_handler import BrowserHandler
@@ -19,13 +20,14 @@ EXPORTS_FOLDER = os.path.abspath(
 )
 
 
-class Site:
+class BaseSite:
     def __init__(self, args):
         self.args = args
 
         self.site_name = type(self).__name__
+        self.site = Site.get(self.site_name, None)
         self.site_displayname = (
-            BashColor.HEADER + BashColor.BOLD + self.site_name + BashColor.END
+            f"{BashColor.HEADER}{BashColor.BOLD}{self.site_name}{BashColor.END}"
             if hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
             else self.site_name
         )

--- a/RatS/base/base_site.py
+++ b/RatS/base/base_site.py
@@ -8,9 +8,8 @@ from configparser import RawConfigParser
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
-from RatS.base.login_failed_exception import LoginFailedException
+from RatS.base.base_exceptions import LoginFailedException, SiteNotReachableException
 from RatS.base.movie_entity import Site
-from RatS.base.site_not_reachable_exception import SiteNotReachableException
 from RatS.utils.bash_color import BashColor
 from RatS.utils.browser_handler import BrowserHandler
 

--- a/RatS/base/captcha_present_exception.py
+++ b/RatS/base/captcha_present_exception.py
@@ -1,5 +1,0 @@
-from RatS.base.login_failed_exception import LoginFailedException
-
-
-class CaptchaPresentException(LoginFailedException):
-    pass

--- a/RatS/base/csv_download_exception.py
+++ b/RatS/base/csv_download_exception.py
@@ -1,5 +1,0 @@
-from RatS.base.rats_exception import RatSException
-
-
-class CSVDownloadFailedException(RatSException):
-    pass

--- a/RatS/base/login_failed_exception.py
+++ b/RatS/base/login_failed_exception.py
@@ -1,5 +1,0 @@
-from RatS.base.rats_exception import RatSException
-
-
-class LoginFailedException(RatSException):
-    pass

--- a/RatS/base/movie_entity.py
+++ b/RatS/base/movie_entity.py
@@ -73,18 +73,24 @@ class Movie(BaseModel):
             return Movie(
                 title=movie_json["title"],
                 year=movie_json["year"] if "year" in movie_json else None,
-                site_data=_convert_dict_to_movie_site_date(movie_json["site_data"]) if "site_data" in movie_json else None,
+                site_data=_convert_dict_to_movie_site_date(movie_json["site_data"])
+                if "site_data" in movie_json
+                else None,
             )
         else:
             return movie_json
 
 
-def _convert_dict_to_movie_site_date(site_data: Dict) -> Dict[Site, SiteSpecificMovieData]:
+def _convert_dict_to_movie_site_date(
+    site_data: Dict,
+) -> Dict[Site, SiteSpecificMovieData]:
     result: Dict[Site, SiteSpecificMovieData] = dict()
     if not site_data:
         return result
     for site_name, site_data in site_data.items():
         site: Site = Site(site_name.upper())
-        site_specific_movie_data: SiteSpecificMovieData = SiteSpecificMovieData.from_json(site_data)
+        site_specific_movie_data: SiteSpecificMovieData = (
+            SiteSpecificMovieData.from_json(site_data)
+        )
         result[site] = site_specific_movie_data
     return result

--- a/RatS/base/movie_entity.py
+++ b/RatS/base/movie_entity.py
@@ -1,8 +1,10 @@
+import json
 from enum import Enum
-from typing import List, Optional, Dict
+from typing import Optional, Dict
+from pydantic import BaseModel
 
 
-class Site(Enum):
+class Site(str, Enum):
     ALLOCINE = "ALLOCINE"
     CRITICKER = "CRITICKER"
     FILMAFFINITY = "FILMAFFINITY"
@@ -21,14 +23,57 @@ class Site(Enum):
     TRAKT = "TRAKT"
 
 
-class SiteSpecificMovieData:
-    id: str
-    url: str
-    my_rating: int  # 1 - 10
+class SiteSpecificMovieData(BaseModel):
+    id: Optional[str]
+    url: Optional[str]
+    my_rating: Optional[int]  # 1 - 10
     # average_rating: float  # 1.0 - 10.0
 
+    def __str__(self):
+        return json.dumps(dict(self), ensure_ascii=False)
 
-class Movie:
-    title: str
+    def __repr__(self):
+        return self.__str__()
+
+    def to_json(self):
+        return self.__str__()
+
+    @staticmethod
+    def from_json(json_dct):
+        data = SiteSpecificMovieData(id=json_dct["id"], url=json_dct["url"])
+        if "my_rating" in json_dct:
+            data.my_rating = json_dct["my_rating"]
+        return data
+
+
+class Movie(BaseModel):
+    title: Optional[str]
     year: Optional[int]
     site_data: Dict[Site, SiteSpecificMovieData] = dict()
+
+    def __str__(self):
+        return json.dumps(self.to_json())
+
+    def __repr__(self):
+        return self.__str__()
+
+    def to_json(self):
+        to_return = {"title": self.title, "year": self.year}
+        site_data = {}
+        for key, site_specific_movie_data in self.site_data.items():
+            site_data[key] = site_specific_movie_data.to_json()
+
+        to_return["siteData"] = site_data
+        return to_return
+
+    @staticmethod
+    def from_json(json_dct):
+        if "id" in json_dct.keys():
+            return SiteSpecificMovieData.from_json(json_dct)
+        elif "siteData" in json_dct.keys():
+            return Movie(
+                title=json_dct["title"],
+                year=json_dct["year"] if "year" in json_dct else None,
+            )
+        else:
+            return json_dct

--- a/RatS/base/movie_entity.py
+++ b/RatS/base/movie_entity.py
@@ -1,0 +1,34 @@
+from enum import Enum
+from typing import List, Optional, Dict
+
+
+class Site(Enum):
+    ALLOCINE = "ALLOCINE"
+    CRITICKER = "CRITICKER"
+    FILMAFFINITY = "FILMAFFINITY"
+    FILMTIPSET = "FILMTIPSET"
+    FLIXSTER = "FLIXSTER"
+    ICHECKMOVIES = "ICHECKMOVIES"
+    IMDB = "IMDB"
+    LETTERBOXD = "LETTERBOXD"
+    LISTAL = "LISTAL"
+    METACRITIC = "METACRITIC"
+    MOVIELENS = "MOVIELENS"
+    MOVIEPILOT = "MOVIEPILOT"
+    PLEX = "PLEX"
+    ROTTENTOMATOES = "ROTTENTOMATOES"
+    TMDB = "TMDB"
+    TRAKT = "TRAKT"
+
+
+class SiteSpecificMovieData:
+    id: str
+    url: str
+    my_rating: int  # 1 - 10
+    # average_rating: float  # 1.0 - 10.0
+
+
+class Movie:
+    title: str
+    year: Optional[int]
+    site_data: Dict[Site, SiteSpecificMovieData]

--- a/RatS/base/movie_entity.py
+++ b/RatS/base/movie_entity.py
@@ -31,4 +31,4 @@ class SiteSpecificMovieData:
 class Movie:
     title: str
     year: Optional[int]
-    site_data: Dict[Site, SiteSpecificMovieData]
+    site_data: Dict[Site, SiteSpecificMovieData] = dict()

--- a/RatS/base/movie_entity.py
+++ b/RatS/base/movie_entity.py
@@ -27,10 +27,9 @@ class SiteSpecificMovieData(BaseModel):
     id: Optional[str]
     url: Optional[str]
     my_rating: Optional[int]  # 1 - 10
-    # average_rating: float  # 1.0 - 10.0
 
     def __str__(self):
-        return json.dumps(dict(self), ensure_ascii=False)
+        return dict(self)
 
     def __repr__(self):
         return self.__str__()
@@ -58,22 +57,27 @@ class Movie(BaseModel):
         return self.__str__()
 
     def to_json(self):
-        to_return = {"title": self.title, "year": self.year}
+        movie_json = {"title": self.title, "year": self.year}
         site_data = {}
         for key, site_specific_movie_data in self.site_data.items():
             site_data[key] = site_specific_movie_data.to_json()
 
-        to_return["siteData"] = site_data
-        return to_return
+        movie_json["site_data"] = site_data
+        # TODO #170 - somehow the site_data breaks the file_import
+        #   raise JSONDecodeError("Expecting value", s, err.value) from None
+        #   json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
+        #   --- it's not about "null" values in movielens
+        #   --- maybe it's the Site enum??
+        return movie_json
 
     @staticmethod
-    def from_json(json_dct):
-        if "id" in json_dct.keys():
-            return SiteSpecificMovieData.from_json(json_dct)
-        elif "siteData" in json_dct.keys():
+    def from_json(movie_json):
+        if "id" in movie_json.keys():
+            return SiteSpecificMovieData.from_json(movie_json)
+        elif "siteData" in movie_json.keys():
             return Movie(
-                title=json_dct["title"],
-                year=json_dct["year"] if "year" in json_dct else None,
+                title=movie_json["title"],
+                year=movie_json["year"] if "year" in movie_json else None,
             )
         else:
-            return json_dct
+            return movie_json

--- a/RatS/base/no_movies_for_insertion.py
+++ b/RatS/base/no_movies_for_insertion.py
@@ -1,5 +1,0 @@
-from RatS.base.exceptions.login_failed_exception import LoginFailedException
-
-
-class NoMoviesForInsertion(LoginFailedException):
-    pass

--- a/RatS/base/no_movies_for_insertion.py
+++ b/RatS/base/no_movies_for_insertion.py
@@ -1,4 +1,4 @@
-from RatS.base.login_failed_exception import LoginFailedException
+from RatS.base.exceptions.login_failed_exception import LoginFailedException
 
 
 class NoMoviesForInsertion(LoginFailedException):

--- a/RatS/base/no_valid_credentials_exception.py
+++ b/RatS/base/no_valid_credentials_exception.py
@@ -1,5 +1,0 @@
-from RatS.base.rats_exception import RatSException
-
-
-class NoValidCredentialsException(RatSException):
-    pass

--- a/RatS/base/rats_exception.py
+++ b/RatS/base/rats_exception.py
@@ -1,2 +1,0 @@
-class RatSException(Exception):
-    pass

--- a/RatS/base/site_not_reachable_exception.py
+++ b/RatS/base/site_not_reachable_exception.py
@@ -1,5 +1,0 @@
-from RatS.base.rats_exception import RatSException
-
-
-class SiteNotReachableException(RatSException):
-    pass

--- a/RatS/criticker/criticker_ratings_inserter.py
+++ b/RatS/criticker/criticker_ratings_inserter.py
@@ -26,7 +26,7 @@ class CritickerRatingsInserter(RatingsInserter):
         return search_result_page.find_all("div", class_="titlerow")
 
     def _is_requested_movie(self, movie: Movie, search_result):
-        if self._is_field_in_parsed_data_for_this_site(movie, "id"):
+        if self._is_id_in_parsed_data_for_this_site(movie):
             return (
                 movie.site_data[self.site.site].id
                 == search_result.find(_class="psi_rateit").find("a")["titleid"]

--- a/RatS/criticker/criticker_ratings_inserter.py
+++ b/RatS/criticker/criticker_ratings_inserter.py
@@ -6,6 +6,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie, Site
 from RatS.criticker.criticker_site import Criticker
 from RatS.imdb.imdb_site import IMDB
 
@@ -14,8 +15,8 @@ class CritickerRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(CritickerRatingsInserter, self).__init__(Criticker(args), args)
 
-    def _search_for_movie(self, movie):
-        search_params = urllib.parse.urlencode({"search": movie["title"]})
+    def _search_for_movie(self, movie: Movie):
+        search_params = urllib.parse.urlencode({"search": movie.title})
         search_url = f"https://www.criticker.com/?{search_params}&type=films"
         self.site.browser.get(search_url)
 
@@ -24,32 +25,32 @@ class CritickerRatingsInserter(RatingsInserter):
         search_result_page = BeautifulSoup(search_result_page, "html.parser")
         return search_result_page.find_all("div", class_="titlerow")
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         if self._is_field_in_parsed_data_for_this_site(movie, "id"):
             return (
-                movie[self.site.site_name.lower()]["id"]
+                movie.site_data[self.site.site].id
                 == search_result.find(_class="psi_rateit").find("a")["titleid"]
             )
         else:
             return self._check_movie_details(movie, search_result)
 
-    def _check_movie_details(self, movie, search_result):
+    def _check_movie_details(self, movie: Movie, search_result):
         movie_url = search_result.find(class_="titlerow_name").find("a")["href"]
         self.site.browser.get(movie_url)
         time.sleep(1)
-        if "imdb" in movie and movie["imdb"]["id"] != "":
+        if Site.IMDB in movie.site_data and movie.site_data[Site.IMDB].id:
             return self._compare_external_links(
-                self.site.browser.page_source, movie, "imdb.com", "imdb"
+                self.site.browser.page_source, movie, "imdb.com", Site.IMDB
             )
         else:
             movie_details_page = BeautifulSoup(
                 self.site.browser.page_source, "html.parser"
             )
             year = movie_details_page.find("h1").find_all("span")[1].get_text()
-            return movie["year"] == int(year)
+            return movie.year == int(year)
 
     @staticmethod
-    def _compare_external_links(page_source, movie, external_url_base, site_name):
+    def _compare_external_links(page_source, movie, external_url_base, site: Site):
         movie_details_page = BeautifulSoup(page_source, "html.parser")
         try:
             external_links = movie_details_page.find(id="fi_info_ext").find_all("a")
@@ -57,12 +58,15 @@ class CritickerRatingsInserter(RatingsInserter):
             return False
         for link in external_links:
             if external_url_base in link["href"]:
-                return IMDB.normalize_imdb_id(
-                    movie[site_name]["id"]
-                ) == IMDB.normalize_imdb_id(link["href"].rstrip("/").split("/")[-1])
+                parsed_imdb_id = IMDB.normalize_imdb_id(
+                    link["href"].rstrip("/").split("/")[-1]
+                )
+                return (
+                    IMDB.normalize_imdb_id(movie.site_data[site].id) == parsed_imdb_id
+                )
         return False
 
-    def _post_movie_rating(self, my_rating):
+    def _post_movie_rating(self, my_rating: int):
         converted_rating = str(my_rating * 10)
         try:
             score = self.site.browser.find_element(
@@ -76,7 +80,7 @@ class CritickerRatingsInserter(RatingsInserter):
         except NoSuchElementException:  # not rated yet
             self._insert_rating(converted_rating)
 
-    def _insert_rating(self, converted_rating):
+    def _insert_rating(self, converted_rating: str):
         score_input = self.site.browser.find_element(
             By.XPATH, "//*[@id='fi_scoring_div']//input"
         )

--- a/RatS/criticker/criticker_ratings_parser.py
+++ b/RatS/criticker/criticker_ratings_parser.py
@@ -65,26 +65,24 @@ class CritickerRatingsParser(RatingsParser):
     def convert_xml_node_to_movie(xml_node):
         film_header = xml_node.find("filmname").text
 
-        movie = Movie()
-        movie.year = int(re.findall(r"\((\d{4})\)", film_header)[0])
-        movie.title = film_header.replace(f"({movie.year})", "").strip()
+        movie_year = int(re.findall(r"\((\d{4})\)", film_header)[0])
+        movie_title = film_header.replace(f"({movie_year})", "").strip()
+        movie = Movie(title=movie_title, year=movie_year)
 
         movie.site_data = dict()
-        movie.site_data[Site.CRITICKER] = SiteSpecificMovieData()
-        movie.site_data[Site.CRITICKER].id = xml_node.find("filmid").text
         movie_link = xml_node.find("filmlink").text
-
         movie_link = re.sub("/rating/.*", "", movie_link).replace("http://", "https://")
 
-        movie.site_data[Site.CRITICKER].url = movie_link
-        movie.site_data[Site.CRITICKER].my_rating = round(
-            float(xml_node.find("rating").text) / 10
+        movie.site_data[Site.CRITICKER] = SiteSpecificMovieData(
+            id=xml_node.find("filmid").text,
+            url=movie_link,
+            my_rating=round(float(xml_node.find("rating").text) / 10),
         )
 
-        movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie.site_data[Site.IMDB].id = xml_node.find("imdbid").text
-        movie.site_data[
-            Site.IMDB
-        ].url = f"https://www.imdb.com/title/{movie.site_data[Site.IMDB].id}"
+        imdb_id = xml_node.find("imdbid").text
+        movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id=imdb_id,
+            url=f"https://www.imdb.com/title/{imdb_id}",
+        )
 
         return movie

--- a/RatS/criticker/criticker_ratings_parser.py
+++ b/RatS/criticker/criticker_ratings_parser.py
@@ -8,6 +8,7 @@ from xml.etree import ElementTree
 from selenium.common.exceptions import TimeoutException
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Site, Movie, SiteSpecificMovieData
 from RatS.criticker.criticker_site import Criticker
 from RatS.utils import file_impex
 
@@ -64,23 +65,25 @@ class CritickerRatingsParser(RatingsParser):
     def convert_xml_node_to_movie(xml_node):
         film_header = xml_node.find("filmname").text
 
-        movie = dict()
-        movie["year"] = int(re.findall(r"\((\d{4})\)", film_header)[0])
-        movie["title"] = film_header.replace(f"({movie['year']})", "").strip()
+        movie = Movie()
+        movie.year = int(re.findall(r"\((\d{4})\)", film_header)[0])
+        movie.title = film_header.replace(f"({movie.year})", "").strip()
 
-        movie["criticker"] = dict()
-        movie["criticker"]["id"] = xml_node.find("filmid").text
+        movie.site_data[Site.CRITICKER] = SiteSpecificMovieData()
+        movie.site_data[Site.CRITICKER].id = xml_node.find("filmid").text
         movie_link = xml_node.find("filmlink").text
 
         movie_link = re.sub("/rating/.*", "", movie_link).replace("http://", "https://")
 
-        movie["criticker"]["url"] = movie_link
-        movie["criticker"]["my_rating"] = round(
+        movie.site_data[Site.CRITICKER].url = movie_link
+        movie.site_data[Site.CRITICKER].my_rating = round(
             float(xml_node.find("rating").text) / 10
         )
 
-        movie["imdb"] = dict()
-        movie["imdb"]["id"] = xml_node.find("imdbid").text
-        movie["imdb"]["url"] = f"https://www.imdb.com/title/{movie['imdb']['id']}"
+        movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie.site_data[Site.IMDB].id = xml_node.find("imdbid").text
+        movie.site_data[
+            Site.IMDB
+        ].url = f"https://www.imdb.com/title/{movie['imdb']['id']}"
 
         return movie

--- a/RatS/criticker/criticker_ratings_parser.py
+++ b/RatS/criticker/criticker_ratings_parser.py
@@ -69,6 +69,7 @@ class CritickerRatingsParser(RatingsParser):
         movie.year = int(re.findall(r"\((\d{4})\)", film_header)[0])
         movie.title = film_header.replace(f"({movie.year})", "").strip()
 
+        movie.site_data = dict()
         movie.site_data[Site.CRITICKER] = SiteSpecificMovieData()
         movie.site_data[Site.CRITICKER].id = xml_node.find("filmid").text
         movie_link = xml_node.find("filmlink").text
@@ -84,6 +85,6 @@ class CritickerRatingsParser(RatingsParser):
         movie.site_data[Site.IMDB].id = xml_node.find("imdbid").text
         movie.site_data[
             Site.IMDB
-        ].url = f"https://www.imdb.com/title/{movie['imdb']['id']}"
+        ].url = f"https://www.imdb.com/title/{movie.site_data[Site.IMDB].id}"
 
         return movie

--- a/RatS/criticker/criticker_site.py
+++ b/RatS/criticker/criticker_site.py
@@ -26,9 +26,7 @@ class Criticker(BaseSite):
             return
         cookie_notice = cookie_notices[0]
         if cookie_notice is not None:
-            cookie_accept_buttons = cookie_notice.find_elements(
-                By.ID, "cookieagree"
-            )
+            cookie_accept_buttons = cookie_notice.find_elements(By.ID, "cookieagree")
             if cookie_accept_buttons is not None and len(cookie_accept_buttons) > 0:
                 cookie_accept_buttons[0].click()
                 time.sleep(1)

--- a/RatS/criticker/criticker_site.py
+++ b/RatS/criticker/criticker_site.py
@@ -1,10 +1,10 @@
-from RatS.base.base_site import Site
 import time
 
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 
-class Criticker(Site):
+class Criticker(BaseSite):
     def __init__(self, args):
         login_form_selector = "//*[@id='i_body']//form"
         self.LOGIN_USERNAME_SELECTOR = (

--- a/RatS/filmaffinity/filmaffinity_ratings_inserter.py
+++ b/RatS/filmaffinity/filmaffinity_ratings_inserter.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie
 from RatS.filmaffinity.filmaffinity_site import FilmAffinity
 
 
@@ -12,10 +13,8 @@ class FilmAffinityRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(FilmAffinityRatingsInserter, self).__init__(FilmAffinity(args), args)
 
-    def _search_for_movie(self, movie):
-        search_params = urllib.parse.urlencode(
-            {"stype": "title", "stext": movie["title"]}
-        )
+    def _search_for_movie(self, movie: Movie):
+        search_params = urllib.parse.urlencode({"stype": "title", "stext": movie.title})
         search_url = f"https://www.filmaffinity.com/en/search.php?{search_params}"
         self.site.browser.get(search_url)
 
@@ -24,14 +23,14 @@ class FilmAffinityRatingsInserter(RatingsInserter):
         search_result_page = BeautifulSoup(search_result_page, "html.parser")
         return search_result_page.find_all("div", class_="se-it")
 
-    def _is_movie_in_search_results(self, movie, search_results):
+    def _is_movie_in_search_results(self, movie: Movie, search_results):
         if self._on_search_result_page():
             for search_result in search_results:
                 if self._is_requested_movie(movie, search_result):
                     return True  # Found
         elif self._on_movie_detail_page():
             # already on movie detail page
-            if self._get_displayed_movie_year() == movie["year"]:
+            if self._get_displayed_movie_year() == movie.year:
                 return True
         return False  # Not Found
 
@@ -48,19 +47,19 @@ class FilmAffinityRatingsInserter(RatingsInserter):
             ).text
         )
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         if self._is_field_in_parsed_data_for_this_site(movie, "id"):
             return (
-                movie[self.site.site_name.lower()]["id"]
+                movie.site_data[self.site.site].id
                 == search_result.find("div", class_="movie-card")["data-movie-id"]
             )
         else:
             return self._check_movie_details(movie, search_result)
 
-    def _check_movie_details(self, movie, search_result):
+    def _check_movie_details(self, movie: Movie, search_result):
         movie_year = int(search_result.find("div", class_="ye-w").get_text())
 
-        if movie["year"] == movie_year:
+        if movie.year == movie_year:
             try:
                 movie_url = search_result.find("div", class_="mc-poster").find("a")[
                     "href"
@@ -72,7 +71,7 @@ class FilmAffinityRatingsInserter(RatingsInserter):
                 return False
         return False
 
-    def _click_rating(self, my_rating):
+    def _click_rating(self, my_rating: int):
         itk = self.site.browser.find_element(
             By.CSS_SELECTOR, ".rating-select"
         ).get_attribute("data-itk")

--- a/RatS/filmaffinity/filmaffinity_ratings_inserter.py
+++ b/RatS/filmaffinity/filmaffinity_ratings_inserter.py
@@ -48,7 +48,7 @@ class FilmAffinityRatingsInserter(RatingsInserter):
         )
 
     def _is_requested_movie(self, movie: Movie, search_result):
-        if self._is_field_in_parsed_data_for_this_site(movie, "id"):
+        if self._is_id_in_parsed_data_for_this_site(movie):
             return (
                 movie.site_data[self.site.site].id
                 == search_result.find("div", class_="movie-card")["data-movie-id"]

--- a/RatS/filmaffinity/filmaffinity_ratings_parser.py
+++ b/RatS/filmaffinity/filmaffinity_ratings_parser.py
@@ -3,6 +3,7 @@ import re
 from bs4 import BeautifulSoup
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData
 from RatS.filmaffinity.filmaffinity_site import FilmAffinity
 
 
@@ -10,7 +11,7 @@ class FilmAffinityRatingsParser(RatingsParser):
     def __init__(self, args):
         super(FilmAffinityRatingsParser, self).__init__(FilmAffinity(args), args)
 
-    def _get_ratings_page(self, page_number):
+    def _get_ratings_page(self, page_number: int):
         return f"{self.site.MY_RATINGS_URL}?p={page_number}"
 
     @staticmethod
@@ -54,20 +55,20 @@ class FilmAffinityRatingsParser(RatingsParser):
     def _get_movie_url(movie_tile):
         return movie_tile.find(class_="mc-title").find("a")["href"]
 
-    def _go_to_movie_details_page(self, movie):
+    def _go_to_movie_details_page(self, movie: Movie):
         # all necessary information is displayed on the search results page
         # so there is no need to go to the movie details page
         pass
 
-    def parse_movie_details_page(self, movie):
+    def parse_movie_details_page(self, movie: Movie):
         movie_details_page = BeautifulSoup(self.site.browser.page_source, "html.parser")
-        movie["year"] = self._get_movie_year(
-            movie_details_page, movie[self.site.site_name.lower()]["id"]
+        movie.year = self._get_movie_year(
+            movie_details_page, movie.site_data[self.site.site].id
         )
-        if self.site.site_name.lower() not in movie:
-            movie[self.site.site_name.lower()] = dict()
-        movie[self.site.site_name.lower()]["my_rating"] = self._get_movie_my_rating(
-            movie_details_page, movie[self.site.site_name.lower()]["id"]
+        if self.site.site not in movie.site_data:
+            movie.site_data[self.site.site] = SiteSpecificMovieData()
+        movie.site_data[self.site.site].my_rating = self._get_movie_my_rating(
+            movie_details_page, movie.site_data[self.site.site].id
         )
 
     @staticmethod

--- a/RatS/filmaffinity/filmaffinity_site.py
+++ b/RatS/filmaffinity/filmaffinity_site.py
@@ -1,10 +1,10 @@
 import time
 
-from RatS.base.base_site import Site
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 
-class FilmAffinity(Site):
+class FilmAffinity(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form[@id='login-form']"
         self.LOGIN_USERNAME_SELECTOR = login_form_selector + "//input[@name='username']"

--- a/RatS/filmtipset/filmtipset_ratings_inserter.py
+++ b/RatS/filmtipset/filmtipset_ratings_inserter.py
@@ -35,7 +35,7 @@ class FilmtipsetRatingsInserter(RatingsInserter):
         return False
 
     def _check_movie_details(self, movie: Movie):
-        if "imdb" in movie:
+        if Site.IMDB in movie.site_data:
             return self._compare_external_links(movie)
         return True
 

--- a/RatS/filmtipset/filmtipset_ratings_parser.py
+++ b/RatS/filmtipset/filmtipset_ratings_parser.py
@@ -7,6 +7,7 @@ from shutil import copyfile
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_downloader import RatingsDownloader
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData, Site
 from RatS.filmtipset.filmtipset_site import Filmtipset
 
 
@@ -55,17 +56,17 @@ class FilmtipsetRatingsParser(RatingsDownloader):
         self.site.browser.find_element(By.XPATH, input_xpath).click()
 
     def _convert_csv_row_to_movie(self, headers, row):
-        movie = dict()
-        movie["title"] = row[headers.index("MovieTitle")]
-        movie[self.site.site_name.lower()] = dict()
+        movie = Movie()
+        movie.title = row[headers.index("MovieTitle")]
+        movie.site_data[self.site.site] = SiteSpecificMovieData()
         parsed_rating = int(row[headers.index("Score")])
-        movie[self.site.site_name.lower()]["my_rating"] = parsed_rating * 2
+        movie.site_data[self.site.site].my_rating = parsed_rating * 2
         self._extract_imdb_information(movie, row[headers.index("IMDB")])
 
         return movie
 
     @staticmethod
-    def _extract_imdb_information(movie, imdb_id):
+    def _extract_imdb_information(movie: Movie, imdb_id):
         try:
             i = int(imdb_id)
             if i < 1:
@@ -73,8 +74,8 @@ class FilmtipsetRatingsParser(RatingsDownloader):
         except ValueError:
             return
 
-        imdb = dict()
-        imdb["id"] = f"tt{int(imdb_id):07d}"
-        imdb["url"] = f"https://www.imdb.com/title/{imdb['id']}"
+        imdb = SiteSpecificMovieData()
+        imdb.id = f"tt{int(imdb_id):07d}"
+        imdb.url = f"https://www.imdb.com/title/{imdb.id}"
 
-        movie["imdb"] = imdb
+        movie.site_data[Site.IMDB] = imdb

--- a/RatS/filmtipset/filmtipset_ratings_parser.py
+++ b/RatS/filmtipset/filmtipset_ratings_parser.py
@@ -56,8 +56,7 @@ class FilmtipsetRatingsParser(RatingsDownloader):
         self.site.browser.find_element(By.XPATH, input_xpath).click()
 
     def _convert_csv_row_to_movie(self, headers, row):
-        movie = Movie()
-        movie.title = row[headers.index("MovieTitle")]
+        movie = Movie(title=row[headers.index("MovieTitle")])
         movie.site_data[self.site.site] = SiteSpecificMovieData()
         parsed_rating = int(row[headers.index("Score")])
         movie.site_data[self.site.site].my_rating = parsed_rating * 2
@@ -74,8 +73,8 @@ class FilmtipsetRatingsParser(RatingsDownloader):
         except ValueError:
             return
 
-        imdb = SiteSpecificMovieData()
-        imdb.id = f"tt{int(imdb_id):07d}"
-        imdb.url = f"https://www.imdb.com/title/{imdb.id}"
-
-        movie.site_data[Site.IMDB] = imdb
+        formatted_imdb_id = f"tt{int(imdb_id):07d}"
+        movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id=formatted_imdb_id,
+            url=f"https://www.imdb.com/title/{formatted_imdb_id}",
+        )

--- a/RatS/filmtipset/filmtipset_site.py
+++ b/RatS/filmtipset/filmtipset_site.py
@@ -1,10 +1,10 @@
-from RatS.base.base_site import Site
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 LOGIN_BUTTON_SELECTOR = '//span[@id="submit" and @class="loginbutton"]'
 
 
-class Filmtipset(Site):
+class Filmtipset(BaseSite):
     def __init__(self, args):
         self.LOGIN_USERNAME_SELECTOR = '//input[@id="user"]'
         self.LOGIN_PASSWORD_SELECTOR = '//input[@id="pass"]'

--- a/RatS/flixster/flixster_ratings_inserter.py
+++ b/RatS/flixster/flixster_ratings_inserter.py
@@ -7,6 +7,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie
 from RatS.flixster.flixster_site import Flixster
 
 
@@ -14,7 +15,7 @@ class FlixsterRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(FlixsterRatingsInserter, self).__init__(Flixster(args), args)
 
-    def _find_movie(self, movie):
+    def _find_movie(self, movie: Movie):
         directly_found = self._search_for_movie(movie)
 
         if directly_found:
@@ -32,7 +33,7 @@ class FlixsterRatingsInserter(RatingsInserter):
         time.sleep(1)
         return self._process_search_results(movie)
 
-    def _process_search_results(self, movie):
+    def _process_search_results(self, movie: Movie):
         iteration = 0
         search_results = None
         while not search_results:
@@ -62,8 +63,8 @@ class FlixsterRatingsInserter(RatingsInserter):
             in self.site.browser.find_element(By.TAG_NAME, "h1").text
         )
 
-    def _search_for_movie(self, movie):
-        search_params = urllib.parse.urlencode({"search": movie["title"]})
+    def _search_for_movie(self, movie: Movie):
+        search_params = urllib.parse.urlencode({"search": movie.title})
         search_url = f"https://www.flixster.com/search/?{search_params}"
         self.site.browser.get(search_url)
         time.sleep(1)
@@ -78,14 +79,14 @@ class FlixsterRatingsInserter(RatingsInserter):
             "li", class_="media"
         )
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         movie_heading = search_result.find("p", class_="heading").find("a")
         movie_url = "https://www.flixster.com" + movie_heading["href"]
         if self._is_field_in_parsed_data_for_this_site(movie, "url"):
-            success = movie[self.site.site_name.lower()]["url"] == movie_url
+            success = movie.site_data[self.site.site].url == movie_url
         else:
             try:
-                success = movie["year"] == int(
+                success = movie.year == int(
                     re.findall(r"\((\d{4})\)", movie_heading.get_text())[-1]
                 )
             except IndexError:
@@ -95,7 +96,7 @@ class FlixsterRatingsInserter(RatingsInserter):
             time.sleep(1)
         return success
 
-    def _click_rating(self, my_rating):
+    def _click_rating(self, my_rating: int):
         movie_id = self.site.browser.find_element(
             By.XPATH, "//meta[@name='movieID']"
         ).get_attribute("content")

--- a/RatS/flixster/flixster_ratings_inserter.py
+++ b/RatS/flixster/flixster_ratings_inserter.py
@@ -82,7 +82,7 @@ class FlixsterRatingsInserter(RatingsInserter):
     def _is_requested_movie(self, movie: Movie, search_result):
         movie_heading = search_result.find("p", class_="heading").find("a")
         movie_url = "https://www.flixster.com" + movie_heading["href"]
-        if self._is_field_in_parsed_data_for_this_site(movie, "url"):
+        if self._is_url_in_parsed_data_for_this_site(movie):
             success = movie.site_data[self.site.site].url == movie_url
         else:
             try:

--- a/RatS/flixster/flixster_ratings_parser.py
+++ b/RatS/flixster/flixster_ratings_parser.py
@@ -1,6 +1,7 @@
 import sys
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.flixster.flixster_site import Flixster
 
 
@@ -8,7 +9,7 @@ class FlixsterRatingsParser(RatingsParser):
     def __init__(self, args):
         super(FlixsterRatingsParser, self).__init__(Flixster(args), args)
 
-    def _get_ratings_page(self, page_number):
+    def _get_ratings_page(self, page_number: int):
         return f"{self.site.MY_RATINGS_URL}&page={page_number}"
 
     def _parse_ratings(self):
@@ -37,15 +38,15 @@ class FlixsterRatingsParser(RatingsParser):
 
     @staticmethod
     def _parse_movie_json(movie_json):
-        movie = dict()
-        movie["title"] = movie_json["movie"]["title"]
-        movie["year"] = int(movie_json["movie"]["year"])
+        movie = Movie()
+        movie.title = movie_json["movie"]["title"]
+        movie.year = int(movie_json["movie"]["year"])
 
-        movie["flixster"] = dict()
-        movie["flixster"]["id"] = movie_json["movie"]["id"]
-        movie["flixster"]["url"] = movie_json["movie"]["url"].replace(
+        movie.site_data[Site.FLIXSTER] = SiteSpecificMovieData()
+        movie.site_data[Site.FLIXSTER].id = movie_json["movie"]["id"]
+        movie.site_data[Site.FLIXSTER].url = movie_json["movie"]["url"].replace(
             "http://", "https://"
         )
-        movie["flixster"]["my_rating"] = int(float(movie_json["score"]) * 2)
+        movie.site_data[Site.FLIXSTER].my_rating = int(float(movie_json["score"]) * 2)
 
         return movie

--- a/RatS/flixster/flixster_ratings_parser.py
+++ b/RatS/flixster/flixster_ratings_parser.py
@@ -38,15 +38,14 @@ class FlixsterRatingsParser(RatingsParser):
 
     @staticmethod
     def _parse_movie_json(movie_json):
-        movie = Movie()
-        movie.title = movie_json["movie"]["title"]
-        movie.year = int(movie_json["movie"]["year"])
-
-        movie.site_data[Site.FLIXSTER] = SiteSpecificMovieData()
-        movie.site_data[Site.FLIXSTER].id = movie_json["movie"]["id"]
-        movie.site_data[Site.FLIXSTER].url = movie_json["movie"]["url"].replace(
-            "http://", "https://"
+        movie = Movie(
+            title=movie_json["movie"]["title"], year=int(movie_json["movie"]["year"])
         )
-        movie.site_data[Site.FLIXSTER].my_rating = int(float(movie_json["score"]) * 2)
+
+        movie.site_data[Site.FLIXSTER] = SiteSpecificMovieData(
+            id=movie_json["movie"]["id"],
+            url=movie_json["movie"]["url"].replace("http://", "https://"),
+            my_rating=int(float(movie_json["score"]) * 2),
+        )
 
         return movie

--- a/RatS/flixster/flixster_site.py
+++ b/RatS/flixster/flixster_site.py
@@ -1,8 +1,8 @@
-from RatS.base.base_site import Site
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 
-class Flixster(Site):
+class Flixster(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form[@name='login']"
         self.LOGIN_USERNAME_SELECTOR = (

--- a/RatS/icheckmovies/icheckmovies_misconfiguration_exception.py
+++ b/RatS/icheckmovies/icheckmovies_misconfiguration_exception.py
@@ -1,4 +1,4 @@
-from RatS.base.rats_exception import RatSException
+from RatS.base.base_exceptions import RatSException
 
 
 class ICheckMoviesMisconfigurationException(RatSException):

--- a/RatS/icheckmovies/icheckmovies_ratings_parser.py
+++ b/RatS/icheckmovies/icheckmovies_ratings_parser.py
@@ -32,15 +32,15 @@ class ICheckMoviesRatingsParser(RatingsParser):
         self._parse_movie_listing_page(movie_ratings_page)
 
     def _parse_movie_tile(self, movie_tile):
-        movie = Movie()
-        movie.title = self._get_movie_title(movie_tile)
-        movie.site_data[self.site.site] = SiteSpecificMovieData()
-        movie.site_data[self.site.site].id = self._get_movie_id(movie_tile)
-        movie.site_data[self.site.site].url = self._get_movie_url(movie_tile)
-        movie.site_data[self.site.site].my_rating = self._get_movie_my_rating(
-            movie_tile
+        movie = Movie(
+            title=self._get_movie_title(movie_tile),
+            year=int(movie_tile.find("span", class_="info").find("a").get_text()),
         )
-        movie.year = int(movie_tile.find("span", class_="info").find("a").get_text())
+        movie.site_data[self.site.site] = SiteSpecificMovieData(
+            id=self._get_movie_id(movie_tile),
+            url=self._get_movie_url(movie_tile),
+            my_rating=self._get_movie_my_rating(movie_tile),
+        )
 
         self._parse_external_links(movie, movie_tile)
 

--- a/RatS/icheckmovies/icheckmovies_ratings_parser.py
+++ b/RatS/icheckmovies/icheckmovies_ratings_parser.py
@@ -4,6 +4,7 @@ import time
 from bs4 import BeautifulSoup
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData
 from RatS.icheckmovies.icheckmovies_site import ICheckMovies
 
 
@@ -31,15 +32,15 @@ class ICheckMoviesRatingsParser(RatingsParser):
         self._parse_movie_listing_page(movie_ratings_page)
 
     def _parse_movie_tile(self, movie_tile):
-        movie = dict()
-        movie["title"] = self._get_movie_title(movie_tile)
-        movie[self.site.site_name.lower()] = dict()
-        movie[self.site.site_name.lower()]["id"] = self._get_movie_id(movie_tile)
-        movie[self.site.site_name.lower()]["url"] = self._get_movie_url(movie_tile)
-        movie[self.site.site_name.lower()]["my_rating"] = self._get_movie_my_rating(
+        movie = Movie()
+        movie.title = self._get_movie_title(movie_tile)
+        movie.site_data[self.site.site] = SiteSpecificMovieData()
+        movie.site_data[self.site.site].id = self._get_movie_id(movie_tile)
+        movie.site_data[self.site.site].url = self._get_movie_url(movie_tile)
+        movie.site_data[self.site.site].my_rating = self._get_movie_my_rating(
             movie_tile
         )
-        movie["year"] = int(movie_tile.find("span", class_="info").find("a").get_text())
+        movie.year = int(movie_tile.find("span", class_="info").find("a").get_text())
 
         self._parse_external_links(movie, movie_tile)
 

--- a/RatS/icheckmovies/icheckmovies_site.py
+++ b/RatS/icheckmovies/icheckmovies_site.py
@@ -1,10 +1,10 @@
-from RatS.base.base_site import Site
+from RatS.base.base_site import BaseSite
 from RatS.icheckmovies.icheckmovies_misconfiguration_exception import (
     ICheckMoviesMisconfigurationException,
 )
 
 
-class ICheckMovies(Site):
+class ICheckMovies(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form"
         self.LOGIN_USERNAME_SELECTOR = (

--- a/RatS/icheckmovies/icheckmovies_site.py
+++ b/RatS/icheckmovies/icheckmovies_site.py
@@ -10,9 +10,7 @@ class ICheckMovies(BaseSite):
         self.LOGIN_USERNAME_SELECTOR = (
             login_form_selector + "//input[@id='UsernameOrEmail']"
         )
-        self.LOGIN_PASSWORD_SELECTOR = (
-            login_form_selector + "//input[@id='Password']"
-        )
+        self.LOGIN_PASSWORD_SELECTOR = login_form_selector + "//input[@id='Password']"
         self.LOGIN_BUTTON_SELECTOR = login_form_selector + "//button[@type='submit']"
         super(ICheckMovies, self).__init__(args)
         self.MY_RATINGS_URL = "https://www.icheckmovies.com/movies/favorited/"

--- a/RatS/imdb/imdb_ratings_inserter.py
+++ b/RatS/imdb/imdb_ratings_inserter.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie
 from RatS.imdb.imdb_site import IMDB
 
 
@@ -13,8 +14,8 @@ class IMDBRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(IMDBRatingsInserter, self).__init__(IMDB(args), args)
 
-    def _find_movie(self, movie):
-        search_params = urllib.parse.urlencode({"q": movie["title"]})
+    def _find_movie(self, movie: Movie):
+        search_params = urllib.parse.urlencode({"q": movie.title})
         search_url = f"https://www.imdb.com/find?s=tt&ref_=fn_al_tt_mr&{search_params}"
         self.site.browser.get(search_url)
         time.sleep(1)
@@ -30,15 +31,15 @@ class IMDBRatingsInserter(RatingsInserter):
             return False
         return False
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         result_annotation = search_result.find(class_="result_text").get_text()
         result_year_list = re.findall(r"\((\d{4})\)", result_annotation)
         if len(result_year_list) > 0:
             result_year = result_year_list[-1]
-            return int(result_year) == movie["year"]
+            return int(result_year) == movie.year
         return False
 
-    def _click_rating(self, my_rating):
+    def _click_rating(self, my_rating: int):
         user_rating_button = self.site.browser.find_element(
             By.XPATH, "//div[@data-testid='hero-rating-bar__user-rating']/button"
         )

--- a/RatS/imdb/imdb_site.py
+++ b/RatS/imdb/imdb_site.py
@@ -1,7 +1,7 @@
 import time
 
+from RatS.base.base_exceptions import CaptchaPresentException
 from RatS.base.base_site import BaseSite
-from RatS.base.captcha_present_exception import CaptchaPresentException
 from selenium.webdriver.common.by import By
 
 
@@ -40,5 +40,5 @@ class IMDB(BaseSite):
             )
 
     @classmethod
-    def normalize_imdb_id(cls, imdb_id):
+    def normalize_imdb_id(cls, imdb_id: str) -> int:
         return int(imdb_id.replace("tt", ""))

--- a/RatS/imdb/imdb_site.py
+++ b/RatS/imdb/imdb_site.py
@@ -1,5 +1,7 @@
 import time
 
+from selenium.webdriver.common.by import By
+
 from RatS.base.base_exceptions import CaptchaPresentException
 from RatS.base.base_site import BaseSite
 from selenium.webdriver.common.by import By

--- a/RatS/imdb/imdb_site.py
+++ b/RatS/imdb/imdb_site.py
@@ -1,11 +1,11 @@
 import time
 
-from RatS.base.base_site import Site
+from RatS.base.base_site import BaseSite
 from RatS.base.captcha_present_exception import CaptchaPresentException
 from selenium.webdriver.common.by import By
 
 
-class IMDB(Site):
+class IMDB(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form[@name='signIn']"
         self.LOGIN_USERNAME_SELECTOR = login_form_selector + "//input[@id='ap_email']"

--- a/RatS/imdb/imdb_site.py
+++ b/RatS/imdb/imdb_site.py
@@ -35,10 +35,13 @@ class IMDB(BaseSite):
             )
             > 0
         ):
+            # time.sleep(30)  # activate this line and handle the captcha manually once using the -x command line option
             self.browser_handler.kill()
             raise CaptchaPresentException(
                 f"Login to {self.site_name} failed.\r\n"
                 "There seems to be a Captcha challenge present for the login. Please try again later.\r\n"
+                "You can also insert a timeout in the code and use the '-x' command line argument "
+                "to handle the captcha manually once.\r\n"
             )
 
     @classmethod

--- a/RatS/letterboxd/letterboxd_ratings_inserter.py
+++ b/RatS/letterboxd/letterboxd_ratings_inserter.py
@@ -2,9 +2,9 @@ import datetime
 import os
 import sys
 import time
+from typing import List
 
 from progressbar import ProgressBar
-
 from selenium.common.exceptions import (
     StaleElementReferenceException,
     ElementNotInteractableException,
@@ -15,6 +15,7 @@ from selenium.webdriver.support import expected_conditions, ui
 from selenium.webdriver.support.wait import WebDriverWait
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie, Site
 from RatS.letterboxd.letterboxd_site import Letterboxd
 from RatS.utils.file_impex import save_movies_to_csv
 
@@ -27,7 +28,7 @@ class LetterboxdRatingsInserter(RatingsInserter):
         super(LetterboxdRatingsInserter, self).__init__(Letterboxd(args), args)
         self.progress_counter_selector = ".import-progress #import-count strong"
 
-    def insert(self, movies, source):
+    def insert(self, movies: List[Movie], source: Site):
         sys.stdout.write(
             f"\r===== {self.site.site_displayname}: posting {len(movies)} movies\r\n"
         )

--- a/RatS/letterboxd/letterboxd_ratings_inserter.py
+++ b/RatS/letterboxd/letterboxd_ratings_inserter.py
@@ -81,19 +81,18 @@ class LetterboxdRatingsInserter(RatingsInserter):
                 continue
 
     def _wait_for_movie_matching(self, wait, movies_count):
-        time.sleep(5)
-        disabled_import_button_selector = "//div[@class='import-buttons']//a[@data-track-category='Import' and contains(@class, 'import-button-disabled')]"  # pylint: disable=line-too-long
-        enabled_import_button_selector = "//div[@class='import-buttons']//a[@data-track-category='Import' and not(contains(@class, 'import-button-disabled'))]"  # pylint: disable=line-too-long
-
-        wait.until(
-            lambda driver: driver.find_element(
-                By.XPATH, disabled_import_button_selector
-            )
-        )
         sys.stdout.write(
             f"\r\n===== {self.site.site_displayname}: matching the movies...\r\n"
         )
         sys.stdout.flush()
+        # disabled_import_button_selector = "//div[@class='import-buttons']//a[@data-track-category='Import' and contains(@class, 'import-button-disabled')]"  # pylint: disable=line-too-long
+        enabled_import_button_selector = "//div[@class='import-buttons']//a[@data-track-category='Import' and not(contains(@class, 'import-button-disabled'))]"  # pylint: disable=line-too-long
+
+        # wait.until(
+        #     lambda driver: driver.find_element(
+        #         By.XPATH, disabled_import_button_selector
+        #     )
+        # )
 
         self._print_progress(movies_count)
 
@@ -118,10 +117,14 @@ class LetterboxdRatingsInserter(RatingsInserter):
         )
 
     def _print_progress(self, movies_count):
+        if not self.progress_bar:
+            self.progress_bar = ProgressBar(
+                max_value=movies_count, redirect_stdout=True
+            )
         while (
             len(
                 self.site.browser.find_elements(
-                    By.CSS_SELECTOR, By.CSS_SELECTOR, self.progress_counter_selector
+                    By.CSS_SELECTOR, self.progress_counter_selector
                 )
             )
             != 0
@@ -131,10 +134,6 @@ class LetterboxdRatingsInserter(RatingsInserter):
                     By.CSS_SELECTOR, self.progress_counter_selector
                 ).text
                 counter = int(displayed_counter.replace(",", "").replace(".", ""))
-                if not self.progress_bar:
-                    self.progress_bar = ProgressBar(
-                        max_value=movies_count, redirect_stdout=True
-                    )
                 self.progress_bar.update(counter)
             except (StaleElementReferenceException, NoSuchElementException):
                 pass

--- a/RatS/letterboxd/letterboxd_ratings_inserter.py
+++ b/RatS/letterboxd/letterboxd_ratings_inserter.py
@@ -51,7 +51,7 @@ class LetterboxdRatingsInserter(RatingsInserter):
 
         self.site.browser_handler.kill()
 
-    def upload_csv_file(self, movies_count):
+    def upload_csv_file(self, movies_count: int):
         self.site.browser.get("https://letterboxd.com/import/")
         time.sleep(1)
         filename = os.path.join(self.exports_folder, CSV_FILE_NAME)

--- a/RatS/letterboxd/letterboxd_ratings_parser.py
+++ b/RatS/letterboxd/letterboxd_ratings_parser.py
@@ -47,14 +47,15 @@ class LetterboxdRatingsParser(RatingsDownloader):
         self.site.browser.get("https://letterboxd.com/data/export/")
 
     def _convert_csv_row_to_movie(self, headers, row):
-        movie = Movie()
-        movie.title = row[headers.index("Name")]
-        movie.year = int(row[headers.index("Year")]) if row[headers.index("Year")] else None
-        movie.site_data[self.site.site] = SiteSpecificMovieData()
-        movie.site_data[self.site.site].url = row[
-            headers.index("Letterboxd URI")
-        ].replace("http://", "https://")
-        movie.site_data[self.site.site].my_rating = int(
-            float(row[headers.index("Rating")]) * 2
+        movie_year = int(row[headers.index("Year")]) if row[headers.index("Year")] else None
+        movie = Movie(
+            title=row[headers.index("Name")],
+            year=movie_year,
+        )
+        movie_url = row[headers.index("Letterboxd URI")].replace("http://", "https://")
+        movie.site_data[self.site.site] = SiteSpecificMovieData(
+            id=movie_url.split("/")[-1],
+            url=movie_url,
+            my_rating=int(float(row[headers.index("Rating")]) * 2),
         )
         return movie

--- a/RatS/letterboxd/letterboxd_ratings_parser.py
+++ b/RatS/letterboxd/letterboxd_ratings_parser.py
@@ -1,7 +1,7 @@
 import os
 
 from RatS.base.base_ratings_downloader import RatingsDownloader
-from RatS.base.movie_entity import SiteSpecificMovieData, Movie
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData
 from RatS.letterboxd.letterboxd_site import Letterboxd
 from RatS.utils import command_line
 from RatS.utils import file_impex

--- a/RatS/letterboxd/letterboxd_ratings_parser.py
+++ b/RatS/letterboxd/letterboxd_ratings_parser.py
@@ -1,6 +1,7 @@
 import os
 
 from RatS.base.base_ratings_downloader import RatingsDownloader
+from RatS.base.movie_entity import SiteSpecificMovieData, Movie
 from RatS.letterboxd.letterboxd_site import Letterboxd
 from RatS.utils import command_line
 from RatS.utils import file_impex
@@ -46,16 +47,14 @@ class LetterboxdRatingsParser(RatingsDownloader):
         self.site.browser.get("https://letterboxd.com/data/export/")
 
     def _convert_csv_row_to_movie(self, headers, row):
-        movie = dict()
-        movie["title"] = row[headers.index("Name")]
-        movie["year"] = (
-            int(row[headers.index("Year")]) if row[headers.index("Year")] else None
-        )
-        movie[self.site.site_name.lower()] = dict()
-        movie[self.site.site_name.lower()]["url"] = row[
+        movie = Movie()
+        movie.title = row[headers.index("Name")]
+        movie.year = int(row[headers.index("Year")]) if row[headers.index("Year")] else None
+        movie.site_data[self.site.site] = SiteSpecificMovieData()
+        movie.site_data[self.site.site].url = row[
             headers.index("Letterboxd URI")
         ].replace("http://", "https://")
-        movie[self.site.site_name.lower()]["my_rating"] = int(
+        movie.site_data[self.site.site].my_rating = int(
             float(row[headers.index("Rating")]) * 2
         )
         return movie

--- a/RatS/letterboxd/letterboxd_ratings_parser.py
+++ b/RatS/letterboxd/letterboxd_ratings_parser.py
@@ -47,10 +47,10 @@ class LetterboxdRatingsParser(RatingsDownloader):
         self.site.browser.get("https://letterboxd.com/data/export/")
 
     def _convert_csv_row_to_movie(self, headers, row):
-        movie_year = int(row[headers.index("Year")]) if row[headers.index("Year")] else None
+        movie_year = row[headers.index("Year")]
         movie = Movie(
             title=row[headers.index("Name")],
-            year=movie_year,
+            year=int(movie_year) if movie_year else None,
         )
         movie_url = row[headers.index("Letterboxd URI")].replace("http://", "https://")
         movie.site_data[self.site.site] = SiteSpecificMovieData(

--- a/RatS/letterboxd/letterboxd_site.py
+++ b/RatS/letterboxd/letterboxd_site.py
@@ -1,10 +1,10 @@
 import time
 
-from RatS.base.base_site import Site
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 
-class Letterboxd(Site):
+class Letterboxd(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form[@id='signin-form']"
         self.LOGIN_USERNAME_SELECTOR = (

--- a/RatS/listal/listal_ratings_inserter.py
+++ b/RatS/listal/listal_ratings_inserter.py
@@ -70,7 +70,9 @@ class ListalRatingsInserter(RatingsInserter):
             return False
 
     @staticmethod
-    def _compare_external_links(page_source, movie: Movie, external_url_base: str, site: Site):
+    def _compare_external_links(
+        page_source, movie: Movie, external_url_base: str, site: Site
+    ):
         movie_details_page = BeautifulSoup(page_source, "html.parser")
         if movie_details_page.find(class_="ratingstable"):
             external_links = movie_details_page.find(class_="ratingstable").find_all(

--- a/RatS/listal/listal_ratings_inserter.py
+++ b/RatS/listal/listal_ratings_inserter.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 from selenium.common.exceptions import TimeoutException
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie, Site
 from RatS.imdb.imdb_site import IMDB
 from RatS.listal.listal_site import Listal
 from RatS.utils import command_line
@@ -43,9 +44,9 @@ class ListalRatingsInserter(RatingsInserter):
                 continue
 
         time.sleep(1)
-        if "imdb" in movie and movie.site_data[Site.IMDB].id != "":
+        if Site.IMDB in movie.site_data and movie.site_data[Site.IMDB].id != "":
             return self._compare_external_links(
-                self.site.browser.page_source, movie, "imdb.com", "imdb"
+                self.site.browser.page_source, movie, "imdb.com", Site.IMDB
             )
         else:
             return self._check_movie_details(movie)
@@ -69,7 +70,7 @@ class ListalRatingsInserter(RatingsInserter):
             return False
 
     @staticmethod
-    def _compare_external_links(page_source, movie, external_url_base, site_name):
+    def _compare_external_links(page_source, movie: Movie, external_url_base: str, site: Site):
         movie_details_page = BeautifulSoup(page_source, "html.parser")
         if movie_details_page.find(class_="ratingstable"):
             external_links = movie_details_page.find(class_="ratingstable").find_all(
@@ -79,7 +80,7 @@ class ListalRatingsInserter(RatingsInserter):
                 if external_url_base in link["href"]:
                     link_href = link["href"].strip("/")
                     return IMDB.normalize_imdb_id(
-                        movie[site_name]["id"]
+                        movie.site_data[site].id
                     ) == IMDB.normalize_imdb_id(link_href.split("/")[-1])
         return False
 

--- a/RatS/listal/listal_ratings_parser.py
+++ b/RatS/listal/listal_ratings_parser.py
@@ -10,7 +10,7 @@ class ListalRatingsParser(RatingsParser):
     def __init__(self, args):
         super(ListalRatingsParser, self).__init__(Listal(args), args)
 
-    def _get_ratings_page(self, page_number):
+    def _get_ratings_page(self, page_number: int):
         return f"https://{self.site.USERNAME}.listal.com/movies/all/{page_number}/?rating=1"
 
     @staticmethod
@@ -60,14 +60,14 @@ class ListalRatingsParser(RatingsParser):
             .replace("http://", "https://")
         )
 
-    def parse_movie_details_page(self, movie):
+    def parse_movie_details_page(self, movie: Movie):
         self.site.handle_request_blocked_by_website()
 
         movie_details_page = BeautifulSoup(self.site.browser.page_source, "html.parser")
-        movie["year"] = self._get_movie_year(movie_details_page)
-        if self.site.site_name.lower() not in movie:
-            movie[self.site.site_name.lower()] = dict()
-        movie[self.site.site_name.lower()]["my_rating"] = self._get_movie_my_rating(
+        movie.year = self._get_movie_year(movie_details_page)
+        if self.site.site not in movie.site_data:
+            movie.site_data[self.site.site] = SiteSpecificMovieData()
+        movie.site_data[self.site.site].my_rating = self._get_movie_my_rating(
             movie_details_page
         )
         self._parse_external_links(movie, movie_details_page)

--- a/RatS/listal/listal_ratings_parser.py
+++ b/RatS/listal/listal_ratings_parser.py
@@ -3,6 +3,7 @@ import re
 from bs4 import BeautifulSoup
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData
 from RatS.listal.listal_site import Listal
 
 

--- a/RatS/listal/listal_site.py
+++ b/RatS/listal/listal_site.py
@@ -1,11 +1,11 @@
-from RatS.base.base_site import Site
 import sys
 import time
 
+from RatS.base.base_site import BaseSite
 from RatS.utils import command_line
 
 
-class Listal(Site):
+class Listal(BaseSite):
     def __init__(self, args):
         login_form_selector = (
             "//*[contains(concat(' ', normalize-space(@class), ' '), ' login-popup ')]"

--- a/RatS/metacritic/metacritic_ratings_inserter.py
+++ b/RatS/metacritic/metacritic_ratings_inserter.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie
 from RatS.metacritic.metacritic_site import Metacritic
 from RatS.utils import command_line
 

--- a/RatS/metacritic/metacritic_ratings_inserter.py
+++ b/RatS/metacritic/metacritic_ratings_inserter.py
@@ -13,8 +13,8 @@ class MetacriticRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(MetacriticRatingsInserter, self).__init__(Metacritic(args), args)
 
-    def _search_for_movie(self, movie):
-        movie_url_path = urllib.parse.quote_plus(movie["title"])
+    def _search_for_movie(self, movie: Movie):
+        movie_url_path = urllib.parse.quote_plus(movie.title)
         search_url = f"https://www.metacritic.com/search/movie/{movie_url_path}/results"
         self.site.browser.get(search_url)
 
@@ -23,10 +23,10 @@ class MetacriticRatingsInserter(RatingsInserter):
         search_result_page = BeautifulSoup(search_result_page, "html.parser")
         return search_result_page.find_all("div", class_="result_wrap")
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         return self._check_movie_details(movie, search_result)
 
-    def _check_movie_details(self, movie, search_result):
+    def _check_movie_details(self, movie: Movie, search_result):
         movie_link = search_result.find(class_="product_title").find("a")
         self.site.browser.get("https://www.metacritic.com" + movie_link["href"])
         time.sleep(1)
@@ -35,16 +35,16 @@ class MetacriticRatingsInserter(RatingsInserter):
         if page_title:
             release_year = page_title.find(class_="release_year")
             if release_year and release_year.get_text():
-                return movie["year"] == int(release_year.get_text())
+                return movie.year == int(release_year.get_text())
         if self.args and self.args.verbose and self.args.verbose >= 3:
             command_line.info(
-                f"{movie['title']} ({movie['year']}): "
+                f"{movie.title} ({movie.year}): "
                 f"No release year displayed on {self.site.site_name} movie detail page {self.site.browser.current_url} "
                 "... skipping "
             )
         return False
 
-    def _click_rating(self, my_rating):
+    def _click_rating(self, my_rating: int):
         stars = self.site.browser.find_element(
             By.CLASS_NAME, "user_rating_widget"
         ).find_elements(By.CLASS_NAME, "ur")

--- a/RatS/metacritic/metacritic_site.py
+++ b/RatS/metacritic/metacritic_site.py
@@ -1,7 +1,7 @@
-from RatS.base.base_site import Site
+from RatS.base.base_site import BaseSite
 
 
-class Metacritic(Site):
+class Metacritic(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form"
         self.LOGIN_USERNAME_SELECTOR = (

--- a/RatS/movielens/movielens_ratings_parser.py
+++ b/RatS/movielens/movielens_ratings_parser.py
@@ -2,6 +2,7 @@ import re
 import sys
 
 from RatS.base.base_ratings_downloader import RatingsDownloader
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData, Site
 from RatS.movielens.movielens_site import Movielens
 
 
@@ -32,9 +33,7 @@ class MovielensRatingsParser(RatingsDownloader):
         movie.site_data[self.site.site] = SiteSpecificMovieData()
         movie.site_data[self.site.site].id = row[headers.index("movie_id")]
         movie_url_path = row[headers.index("movie_id")]
-        movie.site_data[self.site.site][
-            "url"
-        ] = f"https://movielens.org/movies/{movie_url_path}"
+        movie.site_data[self.site.site].url = f"https://movielens.org/movies/{movie_url_path}"
         movie.site_data[self.site.site].my_rating = int(
             float(row[headers.index("rating")]) * 2
         )
@@ -45,20 +44,18 @@ class MovielensRatingsParser(RatingsDownloader):
         return movie
 
     @staticmethod
-    def __extract_tmdb_information(movie, tmdb_id):
-        movie["tmdb"] = SiteSpecificMovieData()
-        movie["tmdb"]["id"] = tmdb_id
-        movie["tmdb"]["url"] = f"https://www.themoviedb.org/movie/{movie['tmdb']['id']}"
+    def __extract_tmdb_information(movie: Movie, tmdb_id: str):
+        movie.site_data[Site.TMDB] = SiteSpecificMovieData()
+        movie.site_data[Site.TMDB].id = tmdb_id
+        movie.site_data[Site.TMDB].url = f"https://www.themoviedb.org/movie/{movie.site_data[Site.TMDB].id}"
 
     @staticmethod
-    def __extract_imdb_information(movie, imdb_id):
+    def __extract_imdb_information(movie: Movie, imdb_id: str):
         movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         movie.site_data[Site.IMDB].id = imdb_id
         if "tt" not in movie.site_data[Site.IMDB].id:
             movie.site_data[Site.IMDB].id = f"tt{imdb_id}"
-        movie.site_data[Site.IMDB][
-            "url"
-        ] = f"https://www.imdb.com/title/{movie['imdb']['id']}"
+        movie.site_data[Site.IMDB].url = f"https://www.imdb.com/title/{movie.site_data[Site.IMDB].id}"
 
     @staticmethod
     def __extract_year(movie, title_field):

--- a/RatS/movielens/movielens_ratings_parser.py
+++ b/RatS/movielens/movielens_ratings_parser.py
@@ -61,7 +61,7 @@ class MovielensRatingsParser(RatingsDownloader):
             imdb_id = f"tt{imdb_id}"
         movie.site_data[Site.IMDB] = SiteSpecificMovieData(
             id=imdb_id,
-            url=f"https://www.imdb.com/title/{movie.site_data[Site.IMDB].id}",
+            url=f"https://www.imdb.com/title/{imdb_id}",
         )
 
     @staticmethod

--- a/RatS/movielens/movielens_site.py
+++ b/RatS/movielens/movielens_site.py
@@ -1,7 +1,7 @@
-from RatS.base.base_site import Site
+from RatS.base.base_site import BaseSite
 
 
-class Movielens(Site):
+class Movielens(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form"
         self.LOGIN_USERNAME_SELECTOR = (

--- a/RatS/moviepilot/moviepilot_ratings_inserter.py
+++ b/RatS/moviepilot/moviepilot_ratings_inserter.py
@@ -5,6 +5,7 @@ import urllib.parse
 from bs4 import BeautifulSoup
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie
 from RatS.moviepilot.moviepilot_site import MoviePilot
 
 
@@ -12,8 +13,8 @@ class MoviePilotRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(MoviePilotRatingsInserter, self).__init__(MoviePilot(args), args)
 
-    def _search_for_movie(self, movie):
-        search_params = urllib.parse.urlencode({"q": movie["title"], "type": "movie"})
+    def _search_for_movie(self, movie: Movie):
+        search_params = urllib.parse.urlencode({"q": movie.title, "type": "movie"})
         search_url = f"https://www.moviepilot.de/suche?{search_params}"
         self.site.browser.get(search_url)
 
@@ -24,10 +25,10 @@ class MoviePilotRatingsInserter(RatingsInserter):
             return search_result_page.find("main").find("ul").find_all("a")
         return []
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         return self._check_movie_details(movie, search_result)
 
-    def _check_movie_details(self, movie, search_result):
+    def _check_movie_details(self, movie: Movie, search_result):
         try:
             movie_url = "https://www.moviepilot.de" + search_result["href"]
         except KeyError:
@@ -38,10 +39,10 @@ class MoviePilotRatingsInserter(RatingsInserter):
         movie_details_page = BeautifulSoup(self.site.browser.page_source, "html.parser")
         copyright_year = movie_details_page.find(attrs={"itemprop": "copyrightYear"})
         if copyright_year:
-            return movie["year"] == int(copyright_year.get_text())
+            return movie.year == int(copyright_year.get_text())
         return False
 
-    def _post_movie_rating(self, my_rating):
+    def _post_movie_rating(self, my_rating: int):
         movie_details_page = BeautifulSoup(self.site.browser.page_source, "html.parser")
         json_from_script = movie_details_page.find(
             "script", attrs={"data-hypernova-key": "FriendsOpinionsModule"}

--- a/RatS/moviepilot/moviepilot_site.py
+++ b/RatS/moviepilot/moviepilot_site.py
@@ -1,10 +1,10 @@
 import time
 
-from RatS.base.base_site import Site
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 
-class MoviePilot(Site):
+class MoviePilot(BaseSite):
     def __init__(self, args):
         login_form_selector = "//*[@data-hypernova-key='LoginModule']//form"
         self.LOGIN_USERNAME_SELECTOR = login_form_selector + "//input[@name='username']"

--- a/RatS/plex/plex_ratings_inserter.py
+++ b/RatS/plex/plex_ratings_inserter.py
@@ -6,6 +6,7 @@ from selenium.webdriver.support import expected_conditions, ui
 from selenium.webdriver.support.wait import WebDriverWait
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie
 from RatS.plex.plex_site import Plex
 
 
@@ -13,8 +14,8 @@ class PlexRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(PlexRatingsInserter, self).__init__(Plex(args), args)
 
-    def _search_for_movie(self, movie):
-        movie_title = urllib.request.quote(movie["title"])
+    def _search_for_movie(self, movie: Movie):
+        movie_title = urllib.request.quote(movie.title)
         search_url = (
             f"http://{self.site.BASE_URL}/library/all?type=1&title={movie_title}"
             "&X-Plex-Container-Start=0"
@@ -30,11 +31,11 @@ class PlexRatingsInserter(RatingsInserter):
         search_results = search_result_page.find_all("video", attrs={"type": "movie"})
         return search_results
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         is_requested_movie = False
 
         if search_result.has_attr("year"):  # some movies might not have a year in Plex
-            is_requested_movie = movie["year"] == int(search_result["year"])
+            is_requested_movie = movie.year == int(search_result["year"])
 
         if is_requested_movie:
             movie_id = search_result["ratingkey"]
@@ -58,7 +59,7 @@ class PlexRatingsInserter(RatingsInserter):
             )
         )
 
-    def _click_rating(self, my_rating):
+    def _click_rating(self, my_rating: int):
         movie_id = self.site.browser.current_url.split("%2Flibrary%2Fmetadata%2F")[-1]
         rate_url = (
             f"http://{self.site.BASE_URL}/:/rate"

--- a/RatS/plex/plex_ratings_parser.py
+++ b/RatS/plex/plex_ratings_parser.py
@@ -3,6 +3,7 @@ import math
 from progressbar import ProgressBar
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData
 from RatS.plex.plex_site import Plex
 
 
@@ -22,7 +23,7 @@ class PlexRatingsParser(RatingsParser):
     def _get_movies_count(movie_ratings_page):
         return int(movie_ratings_page.find("mediacontainer")["totalsize"])
 
-    def _get_ratings_page(self, page_number):
+    def _get_ratings_page(self, page_number: int):
         page_size = 100
         page_start = (page_number - 1) * page_size
         return (
@@ -40,17 +41,17 @@ class PlexRatingsParser(RatingsParser):
         movie = None
 
         if movie_tile.has_attr("userrating"):
-            movie = dict()
-            movie["title"] = movie_tile["title"]
-            movie["year"] = int(movie_tile["year"])
-            movie[self.site.site_name.lower()] = dict()
-            movie[self.site.site_name.lower()]["my_rating"] = round(
+            movie = Movie()
+            movie.title = movie_tile["title"]
+            movie.year = int(movie_tile["year"])
+            movie.site_data[self.site.site] = SiteSpecificMovieData()
+            movie.site_data[self.site.site].my_rating = round(
                 float(movie_tile["userrating"])
             )
-            movie[self.site.site_name.lower()]["id"] = movie_tile["ratingkey"]
+            movie.site_data[self.site.site].id = movie_tile["ratingkey"]
             library_path = "%2Flibrary%2Fmetadata%2F"
-            movie_id = movie[self.site.site_name.lower()]["id"]
-            movie[self.site.site_name.lower()]["url"] = (
+            movie_id = movie.site_data[self.site.site].id
+            movie.site_data[self.site.site].url = (
                 f"http://{self.site.BASE_URL}/web/index.html#!"
                 f"/server/{self.site.SERVER_ID}/details?key={library_path}{movie_id}"
             )

--- a/RatS/plex/plex_ratings_parser.py
+++ b/RatS/plex/plex_ratings_parser.py
@@ -41,19 +41,16 @@ class PlexRatingsParser(RatingsParser):
         movie = None
 
         if movie_tile.has_attr("userrating"):
-            movie = Movie()
-            movie.title = movie_tile["title"]
-            movie.year = int(movie_tile["year"])
-            movie.site_data[self.site.site] = SiteSpecificMovieData()
-            movie.site_data[self.site.site].my_rating = round(
-                float(movie_tile["userrating"])
-            )
-            movie.site_data[self.site.site].id = movie_tile["ratingkey"]
+            movie = Movie(title=movie_tile["title"], year=int(movie_tile["year"]))
             library_path = "%2Flibrary%2Fmetadata%2F"
-            movie_id = movie.site_data[self.site.site].id
-            movie.site_data[self.site.site].url = (
-                f"http://{self.site.BASE_URL}/web/index.html#!"
-                f"/server/{self.site.SERVER_ID}/details?key={library_path}{movie_id}"
+            movie_id = movie_tile["ratingkey"]
+            movie.site_data[self.site.site] = SiteSpecificMovieData(
+                id=movie_id,
+                url=(
+                    f"http://{self.site.BASE_URL}/web/index.html#!"
+                    f"/server/{self.site.SERVER_ID}/details?key={library_path}{movie_id}"
+                ),
+                my_rating=round(float(movie_tile["userrating"])),
             )
 
         self.processed_movies_count += 1

--- a/RatS/plex/plex_site.py
+++ b/RatS/plex/plex_site.py
@@ -4,10 +4,10 @@ import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import ui
 
-from RatS.base.base_site import Site
+from RatS.base.base_site import BaseSite
 
 
-class Plex(Site):
+class Plex(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form"
         self.LOGIN_USERNAME_SELECTOR = login_form_selector + "//input[@id='email']"
@@ -24,7 +24,7 @@ class Plex(Site):
         time.sleep(2)
         self.browser.find_element(By.XPATH, self.LOGIN_METHOD_EMAIL_SELECTOR).click()
         time.sleep(0.5)
-        Site._insert_login_credentials(self)
+        BaseSite._insert_login_credentials(self)
 
     def _user_is_not_logged_in(self):
         return self.USERNAME not in self.browser.page_source

--- a/RatS/rottentomatoes/rottentomatoes_ratings_inserter.py
+++ b/RatS/rottentomatoes/rottentomatoes_ratings_inserter.py
@@ -4,6 +4,7 @@ import urllib.parse
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie
 from RatS.rottentomatoes.rottentomatoes_site import RottenTomatoes
 
 
@@ -11,8 +12,8 @@ class RottenTomatoesRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(RottenTomatoesRatingsInserter, self).__init__(RottenTomatoes(args), args)
 
-    def _search_for_movie(self, movie):
-        search_params = urllib.parse.urlencode({"q": movie["title"], "t": "movie"})
+    def _search_for_movie(self, movie: Movie):
+        search_params = urllib.parse.urlencode({"q": movie.title, "t": "movie"})
         search_url = (
             f"https://www.rottentomatoes.com/api/private/v2.0/search?{search_params}"
         )
@@ -22,13 +23,13 @@ class RottenTomatoesRatingsInserter(RatingsInserter):
         json_data = self.site.get_json_from_html()
         return json_data["movies"]
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         if self._is_field_in_parsed_data_for_this_site(movie, "url"):
             return (
-                movie[self.site.site_name.lower()]["url"]
+                movie.site_data[self.site.site].url
                 == "https://www.rottentomatoes.com" + search_result["url"]
             )
-        elif search_result["year"] and movie["year"] == int(search_result["year"]):
+        elif search_result["year"] and movie.year == int(search_result["year"]):
             self.site.browser.get(
                 "https://www.rottentomatoes.com" + search_result["url"]
             )
@@ -36,7 +37,7 @@ class RottenTomatoesRatingsInserter(RatingsInserter):
             return True
         return False
 
-    def _click_rating(self, my_rating):
+    def _click_rating(self, my_rating: int):
         converted_rating = str(my_rating / 2)
         if len(self.site.browser.find_elements(By.ID, "rating-root")) > 0:
             return

--- a/RatS/rottentomatoes/rottentomatoes_ratings_inserter.py
+++ b/RatS/rottentomatoes/rottentomatoes_ratings_inserter.py
@@ -24,7 +24,7 @@ class RottenTomatoesRatingsInserter(RatingsInserter):
         return json_data["movies"]
 
     def _is_requested_movie(self, movie: Movie, search_result):
-        if self._is_field_in_parsed_data_for_this_site(movie, "url"):
+        if self._is_url_in_parsed_data_for_this_site(movie):
             return (
                 movie.site_data[self.site.site].url
                 == "https://www.rottentomatoes.com" + search_result["url"]

--- a/RatS/rottentomatoes/rottentomatoes_ratings_parser.py
+++ b/RatS/rottentomatoes/rottentomatoes_ratings_parser.py
@@ -1,6 +1,7 @@
 import sys
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.rottentomatoes.rottentomatoes_site import RottenTomatoes
 
 
@@ -8,7 +9,7 @@ class RottenTomatoesRatingsParser(RatingsParser):
     def __init__(self, args):
         super(RottenTomatoesRatingsParser, self).__init__(RottenTomatoes(args), args)
 
-    def _get_ratings_page(self, page_number):
+    def _get_ratings_page(self, page_number: int):
         return f"{self.site.MY_RATINGS_URL}?endCursor={page_number}"
 
     def _parse_ratings(self):
@@ -34,7 +35,7 @@ class RottenTomatoesRatingsParser(RatingsParser):
                 self.movies.append(movie)
                 self.print_progress(movie)
 
-    def print_progress(self, movie):
+    def print_progress(self, movie: Movie):
         if self.args and self.args.verbose and self.args.verbose >= 2:
             sys.stdout.write(
                 f"\r===== {self.site.site_displayname}: [{len(self.movies)}] parsed {movie} \r\n"
@@ -43,7 +44,7 @@ class RottenTomatoesRatingsParser(RatingsParser):
         elif self.args and self.args.verbose and self.args.verbose >= 1:
             sys.stdout.write(
                 f"\r===== {self.site.site_displayname}: [{len(self.movies)}] parsed"
-                f" {movie['title']} ({movie['year']}) \r\n"
+                f" {movie.title} ({movie.year}) \r\n"
             )
             sys.stdout.flush()
         else:
@@ -55,16 +56,16 @@ class RottenTomatoesRatingsParser(RatingsParser):
         if not movie_json["review"]["score"]:
             return None
 
-        movie = dict()
-        movie["title"] = movie_json["item"]["title"]
-        movie["year"] = int(movie_json["item"]["releaseYear"])
+        movie = Movie()
+        movie.title = movie_json["item"]["title"]
+        movie.year = int(movie_json["item"]["releaseYear"])
 
-        movie["rottentomatoes"] = dict()
-        movie["rottentomatoes"]["id"] = movie_json["item"]["rtId"]
-        movie["rottentomatoes"]["url"] = movie_json["item"]["vanityUrl"].replace(
-            "http://", "https://"
-        )
-        movie["rottentomatoes"]["my_rating"] = int(
+        movie.site_data[Site.ROTTENTOMATOES] = SiteSpecificMovieData()
+        movie.site_data[Site.ROTTENTOMATOES].id = movie_json["item"]["rtId"]
+        movie.site_data[Site.ROTTENTOMATOES].url = movie_json["item"][
+            "vanityUrl"
+        ].replace("http://", "https://")
+        movie.site_data[Site.ROTTENTOMATOES].my_rating = int(
             float(movie_json["review"]["score"]) * 2
         )
 

--- a/RatS/rottentomatoes/rottentomatoes_ratings_parser.py
+++ b/RatS/rottentomatoes/rottentomatoes_ratings_parser.py
@@ -56,17 +56,15 @@ class RottenTomatoesRatingsParser(RatingsParser):
         if not movie_json["review"]["score"]:
             return None
 
-        movie = Movie()
-        movie.title = movie_json["item"]["title"]
-        movie.year = int(movie_json["item"]["releaseYear"])
+        movie = Movie(
+            title=movie_json["item"]["title"],
+            year=int(movie_json["item"]["releaseYear"]),
+        )
 
-        movie.site_data[Site.ROTTENTOMATOES] = SiteSpecificMovieData()
-        movie.site_data[Site.ROTTENTOMATOES].id = movie_json["item"]["rtId"]
-        movie.site_data[Site.ROTTENTOMATOES].url = movie_json["item"][
-            "vanityUrl"
-        ].replace("http://", "https://")
-        movie.site_data[Site.ROTTENTOMATOES].my_rating = int(
-            float(movie_json["review"]["score"]) * 2
+        movie.site_data[Site.ROTTENTOMATOES] = SiteSpecificMovieData(
+            id=movie_json["item"]["rtId"],
+            url=movie_json["item"]["vanityUrl"].replace("http://", "https://"),
+            my_rating=int(float(movie_json["review"]["score"]) * 2),
         )
 
         return movie

--- a/RatS/rottentomatoes/rottentomatoes_site.py
+++ b/RatS/rottentomatoes/rottentomatoes_site.py
@@ -1,10 +1,10 @@
 import time
 
-from RatS.base.base_site import Site
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 
-class RottenTomatoes(Site):
+class RottenTomatoes(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form[@id='login-form']"
         self.LOGIN_USERNAME_SELECTOR = (

--- a/RatS/tmdb/tmdb_ratings_parser.py
+++ b/RatS/tmdb/tmdb_ratings_parser.py
@@ -46,14 +46,14 @@ class TMDBRatingsParser(RatingsParser):
         return movie_tile.find(class_="title").find("a").find("h2").get_text()
 
     def _parse_movie_tile(self, movie_tile):
-        movie = Movie()
-        movie.title = self._get_movie_title(movie_tile)
-        movie.year = self._get_movie_year(movie_tile)
-        movie.site_data[self.site.site] = SiteSpecificMovieData()
-        movie.site_data[self.site.site].id = self._get_movie_id(movie_tile)
-        movie.site_data[self.site.site].url = self._get_movie_url(movie_tile)
-        movie.site_data[self.site.site].my_rating = self._get_movie_my_rating(
-            movie_tile
+        movie = Movie(
+            title=self._get_movie_title(movie_tile),
+            year=self._get_movie_year(movie_tile),
+        )
+        movie.site_data[self.site.site] = SiteSpecificMovieData(
+            id=self._get_movie_id(movie_tile),
+            url=self._get_movie_url(movie_tile),
+            my_rating=self._get_movie_my_rating(movie_tile),
         )
 
         return movie

--- a/RatS/tmdb/tmdb_ratings_parser.py
+++ b/RatS/tmdb/tmdb_ratings_parser.py
@@ -1,6 +1,7 @@
 import math
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import SiteSpecificMovieData, Movie
 from RatS.tmdb.tmdb_site import TMDB
 
 
@@ -8,7 +9,7 @@ class TMDBRatingsParser(RatingsParser):
     def __init__(self, args):
         super(TMDBRatingsParser, self).__init__(TMDB(args), args)
 
-    def _get_ratings_page(self, page_number):
+    def _get_ratings_page(self, page_number: int):
         return f"{self.site.MY_RATINGS_URL}?page={page_number}"
 
     @staticmethod
@@ -45,13 +46,13 @@ class TMDBRatingsParser(RatingsParser):
         return movie_tile.find(class_="title").find("a").find("h2").get_text()
 
     def _parse_movie_tile(self, movie_tile):
-        movie = dict()
-        movie["title"] = self._get_movie_title(movie_tile)
-        movie["year"] = self._get_movie_year(movie_tile)
-        movie[self.site.site_name.lower()] = dict()
-        movie[self.site.site_name.lower()]["id"] = self._get_movie_id(movie_tile)
-        movie[self.site.site_name.lower()]["url"] = self._get_movie_url(movie_tile)
-        movie[self.site.site_name.lower()]["my_rating"] = self._get_movie_my_rating(
+        movie = Movie()
+        movie.title = self._get_movie_title(movie_tile)
+        movie.year = self._get_movie_year(movie_tile)
+        movie.site_data[self.site.site] = SiteSpecificMovieData()
+        movie.site_data[self.site.site].id = self._get_movie_id(movie_tile)
+        movie.site_data[self.site.site].url = self._get_movie_url(movie_tile)
+        movie.site_data[self.site.site].my_rating = self._get_movie_my_rating(
             movie_tile
         )
 

--- a/RatS/tmdb/tmdb_site.py
+++ b/RatS/tmdb/tmdb_site.py
@@ -1,10 +1,10 @@
 import time
 
-from RatS.base.base_site import Site
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 
-class TMDB(Site):
+class TMDB(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form[@name='account_login']"
         self.LOGIN_USERNAME_SELECTOR = login_form_selector + "//input[@id='username']"

--- a/RatS/trakt/trakt_ratings_inserter.py
+++ b/RatS/trakt/trakt_ratings_inserter.py
@@ -25,7 +25,7 @@ class TraktRatingsInserter(RatingsInserter):
         return search_result_page.find_all("div", attrs={"data-type": "movie"})
 
     def _is_requested_movie(self, movie: Movie, search_result):
-        if self._is_field_in_parsed_data_for_this_site(movie, "id"):
+        if self._is_id_in_parsed_data_for_this_site(movie):
             return movie.site_data[self.site.site].id == search_result["data-movie-id"]
         else:
             return self._check_movie_details(movie, search_result)

--- a/RatS/trakt/trakt_ratings_inserter.py
+++ b/RatS/trakt/trakt_ratings_inserter.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Movie, Site
 from RatS.imdb.imdb_site import IMDB
 from RatS.trakt.trakt_site import Trakt
 
@@ -13,8 +14,8 @@ class TraktRatingsInserter(RatingsInserter):
     def __init__(self, args):
         super(TraktRatingsInserter, self).__init__(Trakt(args), args)
 
-    def _search_for_movie(self, movie):
-        search_params = urllib.parse.urlencode({"query": movie["title"]})
+    def _search_for_movie(self, movie: Movie):
+        search_params = urllib.parse.urlencode({"query": movie.title})
         search_url = f"https://trakt.tv/search/?{search_params}"
         self.site.open_url_with_521_retry(search_url)
 
@@ -23,16 +24,13 @@ class TraktRatingsInserter(RatingsInserter):
         search_result_page = BeautifulSoup(search_result_page, "html.parser")
         return search_result_page.find_all("div", attrs={"data-type": "movie"})
 
-    def _is_requested_movie(self, movie, search_result):
+    def _is_requested_movie(self, movie: Movie, search_result):
         if self._is_field_in_parsed_data_for_this_site(movie, "id"):
-            return (
-                movie[self.site.site_name.lower()]["id"]
-                == search_result["data-movie-id"]
-            )
+            return movie.site_data[self.site.site].id == search_result["data-movie-id"]
         else:
             return self._check_movie_details(movie, search_result)
 
-    def _check_movie_details(self, movie, search_result):
+    def _check_movie_details(self, movie: Movie, search_result):
         try:
             movie_url = "https://trakt.tv" + search_result["data-url"]
         except KeyError:
@@ -40,23 +38,23 @@ class TraktRatingsInserter(RatingsInserter):
 
         self.site.open_url_with_521_retry(movie_url)
         time.sleep(1)
-        if "imdb" in movie and movie["imdb"]["id"] != "":
+        if Site.IMDB in movie.site_data and movie.site_data[Site.IMDB].id:
             return self._compare_external_links(
-                self.site.browser.page_source, movie, "imdb.com", "imdb"
+                self.site.browser.page_source, movie, "imdb.com", Site.IMDB
             )
-        elif "tmdb" in movie and movie["tmdb"]["id"] != "":
+        elif Site.TMDB in movie and movie.site_data[Site.TMDB].id != "":
             return self._compare_external_links(
-                self.site.browser.page_source, movie, "themoviedb.org", "tmdb"
+                self.site.browser.page_source, movie, "themoviedb.org", Site.TMDB
             )
         else:
             movie_details_page = BeautifulSoup(
                 self.site.browser.page_source, "html.parser"
             )
             year_str = movie_details_page.find(class_="year").get_text().strip()
-            return year_str != "" and movie["year"] == int(year_str)
+            return year_str != "" and movie.year == int(year_str)
 
     @staticmethod
-    def _compare_external_links(page_source, movie, external_url_base, site_name):
+    def _compare_external_links(page_source, movie, external_url_base, site: Site):
         movie_details_page = BeautifulSoup(page_source, "html.parser")
         external_links = (
             movie_details_page.find(id="info-wrapper")
@@ -65,14 +63,14 @@ class TraktRatingsInserter(RatingsInserter):
         )
         for link in external_links:
             if external_url_base in link["href"]:
-                if site_name == "imdb":
+                if site == Site.IMDB:
                     return IMDB.normalize_imdb_id(
-                        movie["imdb"]["id"]
+                        movie.site_data[Site.IMDB].id
                     ) == IMDB.normalize_imdb_id(link["href"].split("/")[-1])
-                return movie[site_name]["id"] == link["href"].split("/")[-1]
+                return movie.site_data[site].id == link["href"].split("/")[-1]
         return False
 
-    def _click_rating(self, my_rating):
+    def _click_rating(self, my_rating: int):
         user_rating_section = self.site.browser.find_element(
             By.CLASS_NAME, "summary-user-rating"
         )

--- a/RatS/trakt/trakt_ratings_parser.py
+++ b/RatS/trakt/trakt_ratings_parser.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 
 from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData
 from RatS.trakt.trakt_site import Trakt
 
 
@@ -8,7 +9,7 @@ class TraktRatingsParser(RatingsParser):
     def __init__(self, args):
         super(TraktRatingsParser, self).__init__(Trakt(args), args)
 
-    def _get_ratings_page(self, page_number):
+    def _get_ratings_page(self, page_number: int):
         return f"{self.site.MY_RATINGS_URL}?page={page_number}"
 
     @staticmethod
@@ -49,13 +50,13 @@ class TraktRatingsParser(RatingsParser):
     def _get_movie_url(movie_tile):
         return f"https://trakt.tv{movie_tile['data-url']}"
 
-    def parse_movie_details_page(self, movie):
+    def parse_movie_details_page(self, movie: Movie):
         movie_details_page = BeautifulSoup(self.site.browser.page_source, "html.parser")
         movie_year = movie_details_page.find(class_="year").get_text()
-        movie["year"] = int(movie_year) if movie_year else 0
-        if self.site.site_name.lower() not in movie:
-            movie[self.site.site_name.lower()] = dict()
-        movie[self.site.site_name.lower()]["my_rating"] = self._get_movie_my_rating(
+        movie.year = int(movie_year) if movie_year else 0
+        if self.site.site not in movie.site_data:
+            movie.site_data[self.site.site] = SiteSpecificMovieData()
+        movie.site_data[self.site.site].my_rating = self._get_movie_my_rating(
             movie_details_page
         )
         self._parse_external_links(movie, movie_details_page)

--- a/RatS/trakt/trakt_site.py
+++ b/RatS/trakt/trakt_site.py
@@ -1,10 +1,10 @@
 import time
 
-from RatS.base.base_site import Site
 from selenium.webdriver.common.by import By
+from RatS.base.base_site import BaseSite
 
 
-class Trakt(Site):
+class Trakt(BaseSite):
     def __init__(self, args):
         login_form_selector = "//form[@id='new_user']"
         self.LOGIN_USERNAME_SELECTOR = login_form_selector + "//input[@id='user_login']"

--- a/RatS/utils/file_impex.py
+++ b/RatS/utils/file_impex.py
@@ -48,13 +48,15 @@ def load_movies_from_csv(filepath, encoding="UTF-8"):
 
 
 def convert_csv_row_to_movie(headers, row):
-    movie = dict()
-    movie["title"] = row[headers.index("Title")]
-    movie["year"] = int(row[headers.index("Year")])
-    movie["imdb"] = dict()
-    movie["imdb"]["id"] = row[headers.index("Const")]
-    movie["imdb"]["url"] = row[headers.index("URL")].replace("http://", "https://")
-    movie["imdb"]["my_rating"] = int(row[headers.index("Your Rating")])
+    movie = Movie()
+    movie.title = row[headers.index("Title")]
+    movie.year = int(row[headers.index("Year")])
+    movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+    movie.site_data[Site.IMDB].id = row[headers.index("Const")]
+    movie.site_data[Site.IMDB]["url"] = row[headers.index("URL")].replace(
+        "http://", "https://"
+    )
+    movie.site_data[Site.IMDB]["my_rating"] = int(row[headers.index("Your Rating")])
     return movie
 
 

--- a/RatS/utils/file_impex.py
+++ b/RatS/utils/file_impex.py
@@ -5,7 +5,7 @@ import os
 import sys
 import time
 import zipfile
-from typing import List
+from typing import List, Dict
 
 from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 
@@ -25,10 +25,7 @@ def load_movies_from_json(
     folder: str = EXPORTS_FOLDER, filename: str = "import.json"
 ) -> List[Movie]:
     with open(os.path.join(folder, filename), encoding="UTF-8") as input_file:
-        print(filename)
-        # return json.load(input_file, object_hook=Movie.from_json)  # TODO #170
-        load = json.loads(input_file.read())
-        print(load)
+        load: Dict = json.loads(input_file.read())
         return [Movie.from_json(item) for item in load]
 
 

--- a/RatS/utils/file_impex.py
+++ b/RatS/utils/file_impex.py
@@ -25,7 +25,11 @@ def load_movies_from_json(
     folder: str = EXPORTS_FOLDER, filename: str = "import.json"
 ) -> List[Movie]:
     with open(os.path.join(folder, filename), encoding="UTF-8") as input_file:
-        return json.load(input_file, object_hook=Movie.from_json)
+        print(filename)
+        # return json.load(input_file, object_hook=Movie.from_json)  # TODO #170
+        load = json.loads(input_file.read())
+        print(load)
+        return [Movie.from_json(item) for item in load]
 
 
 def save_movies_to_json(
@@ -61,8 +65,10 @@ def load_movies_from_csv(filepath: str, encoding: str = "UTF-8") -> List[Movie]:
 
 
 def convert_csv_row_to_movie(headers, row) -> Movie:
+    movie_year = row[headers.index("Year")]
     movie = Movie(
-        title=row[headers.index("Title")], year=int(row[headers.index("Year")])
+        title=row[headers.index("Title")],
+        year=int(movie_year) if movie_year else 0,
     )
     movie.site_data[Site.IMDB] = SiteSpecificMovieData(
         id=row[headers.index("Const")],

--- a/RatS/utils/file_impex.py
+++ b/RatS/utils/file_impex.py
@@ -5,6 +5,9 @@ import os
 import sys
 import time
 import zipfile
+from typing import List
+
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 
 EXPORTS_FOLDER = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "RatS", "exports")
@@ -12,19 +15,19 @@ EXPORTS_FOLDER = os.path.abspath(
 CSV_HEADER = "Const,Your Rating,Date Rated,Title,URL,Title Type,IMDb Rating,Runtime (mins),Year,Genres,Num Votes,Release Date,Directors\n"  # pylint: disable=line-too-long
 
 
-def load_movies_from_json(folder=EXPORTS_FOLDER, filename="import.json"):
+def load_movies_from_json(folder: str = EXPORTS_FOLDER, filename: str = "import.json") -> List[Movie]:
     with open(os.path.join(folder, filename), encoding="UTF-8") as input_file:
-        return json.load(input_file)
+        return json.load(input_file)  # TODO convert into Movie
 
 
-def save_movies_to_json(movies, folder=EXPORTS_FOLDER, filename="export.json"):
+def save_movies_to_json(movies: List[Movie], folder: str = EXPORTS_FOLDER, filename: str = "export.json"):
     if not os.path.exists(folder):
         os.makedirs(folder)
     with open(os.path.join(folder, filename), "w+", encoding="UTF-8") as output_file:
         output_file.write(json.dumps(movies))
 
 
-def wait_for_file_to_exist(filepath, seconds=30):
+def wait_for_file_to_exist(filepath: str, seconds: int = 30):
     iteration = 0
     while iteration < seconds:
         iteration += 1
@@ -37,7 +40,7 @@ def wait_for_file_to_exist(filepath, seconds=30):
     raise IOError(f"Could not access {filepath} after {seconds} seconds")
 
 
-def load_movies_from_csv(filepath, encoding="UTF-8"):
+def load_movies_from_csv(filepath: str, encoding: str = "UTF-8") -> List[Movie]:
     sys.stdout.write("===== getting movies from CSV\r\n")
     sys.stdout.flush()
     wait_for_file_to_exist(filepath)
@@ -47,21 +50,21 @@ def load_movies_from_csv(filepath, encoding="UTF-8"):
         return [convert_csv_row_to_movie(headers, row) for row in reader]
 
 
-def convert_csv_row_to_movie(headers, row):
+def convert_csv_row_to_movie(headers, row) -> Movie:
     movie = Movie()
     movie.title = row[headers.index("Title")]
     movie.year = int(row[headers.index("Year")])
     movie.site_data[Site.IMDB] = SiteSpecificMovieData()
     movie.site_data[Site.IMDB].id = row[headers.index("Const")]
-    movie.site_data[Site.IMDB]["url"] = row[headers.index("URL")].replace(
+    movie.site_data[Site.IMDB].url = row[headers.index("URL")].replace(
         "http://", "https://"
     )
-    movie.site_data[Site.IMDB]["my_rating"] = int(row[headers.index("Your Rating")])
+    movie.site_data[Site.IMDB].my_rating = int(row[headers.index("Your Rating")])
     return movie
 
 
 def save_movies_to_csv(
-    movies, folder=EXPORTS_FOLDER, filename="export.csv", rating_source="imdb"
+    movies: List[Movie], folder: str = EXPORTS_FOLDER, filename: str = "export.csv", rating_source: Site = Site.IMDB
 ):
     sys.stdout.write("===== saving movies to CSV\r\n")
     sys.stdout.flush()
@@ -73,22 +76,22 @@ def save_movies_to_csv(
             output_file.write(convert_movie_to_csv(movies, i, rating_source))
 
 
-def convert_movie_to_csv(movies, index, rating_source):
-    imdb_id = movies[index]["imdb"]["id"] if "imdb" in movies[index] else ""
-    imdb_url = movies[index]["imdb"]["url"] if "imdb" in movies[index] else ""
+def convert_movie_to_csv(movies: List[Movie], index: int, rating_source: Site) -> str:
+    imdb_id = movies[index].site_data[Site.IMDB].id if Site.IMDB in movies[index].site_data else ""
+    imdb_url = movies[index].site_data[Site.IMDB].url if Site.IMDB in movies[index].site_data else ""
     movie_csv = (
         ""
         + ""
         + imdb_id
         + ","
         + ""
-        + str(movies[index][rating_source.lower()]["my_rating"])
+        + str(movies[index].site_data[rating_source].my_rating)
         + ","
         + ""
         + datetime.datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d")
         + ","
         + '"'
-        + movies[index]["title"]
+        + movies[index].title
         + '",'
         + ""
         + imdb_url
@@ -97,12 +100,12 @@ def convert_movie_to_csv(movies, index, rating_source):
         + ","
         + ","
         + ""
-        + str(movies[index]["year"])
+        + str(movies[index].year)
         + ","
         + ","
         + ","
         + ""
-        + str(movies[index]["year"])
+        + str(movies[index].year)
         + "-01-01,"
         + ""
         + "\n"
@@ -111,7 +114,7 @@ def convert_movie_to_csv(movies, index, rating_source):
 
 
 def extract_file_from_archive(
-    path_to_zip_file, filename_to_extract, directory_to_extract_to
+    path_to_zip_file: str, filename_to_extract: str, directory_to_extract_to: str
 ):
     if not os.path.exists(directory_to_extract_to):
         os.makedirs(directory_to_extract_to)

--- a/RatS/utils/file_impex.py
+++ b/RatS/utils/file_impex.py
@@ -24,7 +24,7 @@ def save_movies_to_json(movies: List[Movie], folder: str = EXPORTS_FOLDER, filen
     if not os.path.exists(folder):
         os.makedirs(folder)
     with open(os.path.join(folder, filename), "w+", encoding="UTF-8") as output_file:
-        output_file.write(json.dumps(movies))
+        output_file.write(json.dumps(movies))  # TODO convert Movie to dict to json
 
 
 def wait_for_file_to_exist(filepath: str, seconds: int = 30):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ configparser==5.3.0
 progressbar2==4.0.0
 selenium==4.4.3
 xvfbwrapper==0.2.9
-black==20.8b1
-pydantic==1.7.3
+black==22.1.0
+pydantic==1.9.0
 jsonpickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ configparser==5.3.0
 progressbar2==4.0.0
 selenium==4.4.3
 xvfbwrapper==0.2.9
-black
+black==20.8b1
+pydantic==1.7.3
+jsonpickle

--- a/tests/assets/trakt/exports.json
+++ b/tests/assets/trakt/exports.json
@@ -1,1 +1,11 @@
-[{"title": "Fight Club", "imdb": {"id": "tt0137523", "url": "http://www.imdb.com/title/tt0137523", "my_rating": "", "overall_rating": ""}, "trakt": {"id": "432", "url": "https://trakt.tv/movies/fight-club-1999", "my_rating": "10", "overall_rating": "89%"}, "tmdb": {"id": "550", "url": "https://www.themoviedb.org/movie/550", "my_rating": "", "overall_rating": ""}, "movielens": {"id": "", "url": "", "my_rating": "", "overall_rating": ""}}]
+[
+  {
+    "title": "Fight Club",
+    "year": 1999,
+    "site_data": {
+      "IMDB": {"id": "tt0137523", "url": "https://www.imdb.com/title/tt0137523/", "my_rating": 10},
+      "trakt": {"id": "432", "url": "https://trakt.tv/movies/fight-club-1999", "my_rating": 10},
+      "tmdb": {"id": "550", "url": "https://www.themoviedb.org/movie/550", "my_rating": null}
+    }
+  }
+]

--- a/tests/functional/sites/test_allocine_site.py
+++ b/tests/functional/sites/test_allocine_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.allocine.allocine_site import AlloCine
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class AlloCineSiteTest(TestCase):
     def setUp(self):
         self.site = AlloCine(None)

--- a/tests/functional/sites/test_criticker_site.py
+++ b/tests/functional/sites/test_criticker_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.criticker.criticker_site import Criticker
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class CritickerSiteTest(TestCase):
     def setUp(self):
         self.site = Criticker(None)

--- a/tests/functional/sites/test_filmaffinity_site.py
+++ b/tests/functional/sites/test_filmaffinity_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.filmaffinity.filmaffinity_site import FilmAffinity
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class FilmAffinitySiteTest(TestCase):
     def setUp(self):
         self.site = FilmAffinity(None)

--- a/tests/functional/sites/test_filmtipset_site.py
+++ b/tests/functional/sites/test_filmtipset_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.filmtipset.filmtipset_site import Filmtipset
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class FilmtipsetSiteTest(TestCase):
     def setUp(self):
         self.site = Filmtipset(None)

--- a/tests/functional/sites/test_flixster_site.py
+++ b/tests/functional/sites/test_flixster_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.flixster.flixster_site import Flixster
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class FlixsterSiteTest(TestCase):
     def setUp(self):
         self.site = Flixster(None)

--- a/tests/functional/sites/test_icheckmovies_site.py
+++ b/tests/functional/sites/test_icheckmovies_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.icheckmovies.icheckmovies_site import ICheckMovies
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class ICheckMoviesSiteTest(TestCase):
     def setUp(self):
         self.site = ICheckMovies(None)

--- a/tests/functional/sites/test_imdb_site.py
+++ b/tests/functional/sites/test_imdb_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.imdb.imdb_site import IMDB
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class IMDBSiteTest(TestCase):
     def setUp(self):
         self.site = IMDB(None)

--- a/tests/functional/sites/test_letterboxd_site.py
+++ b/tests/functional/sites/test_letterboxd_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.letterboxd.letterboxd_site import Letterboxd
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class LetterboxdSiteTest(TestCase):
     def setUp(self):
         self.site = Letterboxd(None)

--- a/tests/functional/sites/test_listal_site.py
+++ b/tests/functional/sites/test_listal_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.listal.listal_site import Listal
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class ListalSiteTest(TestCase):
     def setUp(self):
         self.site = Listal(None)

--- a/tests/functional/sites/test_metacritic_site.py
+++ b/tests/functional/sites/test_metacritic_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.metacritic.metacritic_site import Metacritic
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class MetacriticSiteTest(TestCase):
     def setUp(self):
         self.site = Metacritic(None)

--- a/tests/functional/sites/test_movielens_site.py
+++ b/tests/functional/sites/test_movielens_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.movielens.movielens_site import Movielens
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class MovielensSiteTest(TestCase):
     def setUp(self):
         self.site = Movielens(None)

--- a/tests/functional/sites/test_moviepilot_site.py
+++ b/tests/functional/sites/test_moviepilot_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.moviepilot.moviepilot_site import MoviePilot
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class MoviePilotSiteTest(TestCase):
     def setUp(self):
         self.site = MoviePilot(None)

--- a/tests/functional/sites/test_plex_site.py
+++ b/tests/functional/sites/test_plex_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.plex.plex_site import Plex
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class PlexSiteTest(TestCase):
     def setUp(self):
         self.site = Plex(None)

--- a/tests/functional/sites/test_rottentomatoes_site.py
+++ b/tests/functional/sites/test_rottentomatoes_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.rottentomatoes.rottentomatoes_site import RottenTomatoes
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class RottenTomatoesSiteTest(TestCase):
     def setUp(self):
         self.site = RottenTomatoes(None)

--- a/tests/functional/sites/test_tmdb_site.py
+++ b/tests/functional/sites/test_tmdb_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.tmdb.tmdb_site import TMDB
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class TMDBSiteTest(TestCase):
     def setUp(self):
         self.site = TMDB(None)

--- a/tests/functional/sites/test_trakt_site.py
+++ b/tests/functional/sites/test_trakt_site.py
@@ -4,7 +4,7 @@ from unittest import skip
 from RatS.trakt.trakt_site import Trakt
 
 
-@skip("this test is unstable on travis")
+@skip("this test is unstable on CI")
 class TraktSiteTest(TestCase):
     def setUp(self):
         self.site = Trakt(None)

--- a/tests/unit/allocine/test_allocine_ratings_inserter.py
+++ b/tests/unit/allocine/test_allocine_ratings_inserter.py
@@ -14,13 +14,12 @@ class AlloCineRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
         with open(
             os.path.join(TESTDATA_PATH, "allocine", "search_result.html"),
             encoding="UTF-8",
@@ -88,9 +87,7 @@ class AlloCineRatingsInserterTest(TestCase):
         inserter.site.site_name = "AlloCine"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -117,9 +114,7 @@ class AlloCineRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
+        movie2 = Movie(title="The Matrix", year=1995)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/allocine/test_allocine_ratings_inserter.py
+++ b/tests/unit/allocine/test_allocine_ratings_inserter.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from RatS.allocine.allocine_ratings_inserter import AlloCineRatingsInserter
+from RatS.base.movie_entity import Site
 
 TESTDATA_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "assets")
@@ -13,13 +14,13 @@ class AlloCineRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
         with open(
             os.path.join(TESTDATA_PATH, "allocine", "search_result.html"),
             encoding="UTF-8",
@@ -71,7 +72,7 @@ class AlloCineRatingsInserterTest(TestCase):
         inserter.site.site_name = "AlloCine"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -87,7 +88,7 @@ class AlloCineRatingsInserterTest(TestCase):
         inserter.site.site_name = "AlloCine"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -116,7 +117,7 @@ class AlloCineRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
 

--- a/tests/unit/allocine/test_allocine_ratings_inserter.py
+++ b/tests/unit/allocine/test_allocine_ratings_inserter.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from RatS.allocine.allocine_ratings_inserter import AlloCineRatingsInserter
-from RatS.base.movie_entity import Site
+from RatS.base.movie_entity import Site, Movie, SiteSpecificMovieData
 
 TESTDATA_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "assets")
@@ -19,8 +19,8 @@ class AlloCineRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
         with open(
             os.path.join(TESTDATA_PATH, "allocine", "search_result.html"),
             encoding="UTF-8",
@@ -89,8 +89,8 @@ class AlloCineRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -118,8 +118,8 @@ class AlloCineRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
+        movie2.title = "The Matrix"
+        movie2.year = 1995
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/allocine/test_allocine_ratings_parser.py
+++ b/tests/unit/allocine/test_allocine_ratings_parser.py
@@ -51,6 +51,7 @@ class AlloCineRatingsParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.ALLOCINE
         parser.site.site_name = "AlloCine"
         parser.site.browser = browser_mock
         parser.args = None
@@ -60,11 +61,11 @@ class AlloCineRatingsParserTest(TestCase):
         self.assertEqual(2, parse_movie_mock.call_count)
         self.assertEqual(2, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
-        self.assertEqual("21189", parser.movies[0].site_data[parser.site.site].id)
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ALLOCINE]))
+        self.assertEqual("21189", parser.movies[0].site_data[Site.ALLOCINE].id)
         self.assertEqual(
             "https://www.allocine.fr/film/fichefilm_gen_cfilm=21189.html",
-            parser.movies[0].site_data[parser.site.site].url,
+            parser.movies[0].site_data[Site.ALLOCINE].url,
         )
 
     @patch("RatS.utils.browser_handler.Firefox")

--- a/tests/unit/allocine/test_allocine_ratings_parser.py
+++ b/tests/unit/allocine/test_allocine_ratings_parser.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from RatS.allocine.allocine_ratings_parser import AlloCineRatingsParser
+from RatS.base.movie_entity import Site, Movie, SiteSpecificMovieData
 
 TESTDATA_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "assets")
@@ -58,11 +59,12 @@ class AlloCineRatingsParserTest(TestCase):
 
         self.assertEqual(2, parse_movie_mock.call_count)
         self.assertEqual(2, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("21189", parser.movies[0]["allocine"]["id"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
+        self.assertEqual("21189", parser.movies[0].site_data[parser.site.site].id)
         self.assertEqual(
             "https://www.allocine.fr/film/fichefilm_gen_cfilm=21189.html",
-            parser.movies[0]["allocine"]["url"],
+            parser.movies[0].site_data[parser.site.site].url,
         )
 
     @patch("RatS.utils.browser_handler.Firefox")
@@ -73,6 +75,7 @@ class AlloCineRatingsParserTest(TestCase):
         parser = AlloCineRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.ALLOCINE
         parser.site.site_name = "AlloCine"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
@@ -82,4 +85,4 @@ class AlloCineRatingsParserTest(TestCase):
 
         self.assertEqual(1999, movie.year)
         self.assertEqual("Fight Club", movie.title)
-        self.assertEqual(9, movie["allocine"]["my_rating"])
+        self.assertEqual(9, movie.site_data[Site.ALLOCINE].my_rating)

--- a/tests/unit/allocine/test_allocine_ratings_parser.py
+++ b/tests/unit/allocine/test_allocine_ratings_parser.py
@@ -76,10 +76,10 @@ class AlloCineRatingsParserTest(TestCase):
         parser.site.site_name = "AlloCine"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
-        movie = dict()
+        movie = Movie()
 
         parser.parse_movie_details_page(movie)
 
-        self.assertEqual(1999, movie["year"])
-        self.assertEqual("Fight Club", movie["title"])
+        self.assertEqual(1999, movie.year)
+        self.assertEqual("Fight Club", movie.title)
         self.assertEqual(9, movie["allocine"]["my_rating"])

--- a/tests/unit/allocine/test_allocine_ratings_parser.py
+++ b/tests/unit/allocine/test_allocine_ratings_parser.py
@@ -61,7 +61,9 @@ class AlloCineRatingsParserTest(TestCase):
         self.assertEqual(2, parse_movie_mock.call_count)
         self.assertEqual(2, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ALLOCINE]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ALLOCINE])
+        )
         self.assertEqual("21189", parser.movies[0].site_data[Site.ALLOCINE].id)
         self.assertEqual(
             "https://www.allocine.fr/film/fichefilm_gen_cfilm=21189.html",
@@ -80,7 +82,7 @@ class AlloCineRatingsParserTest(TestCase):
         parser.site.site_name = "AlloCine"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
-        movie = Movie()
+        movie = Movie(title="doesn't matter right now")
 
         parser.parse_movie_details_page(movie)
 

--- a/tests/unit/base/test_base_ratings_inserter.py
+++ b/tests/unit/base/test_base_ratings_inserter.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.movie_entity import Site, SiteSpecificMovieData, Movie
 
 
 class BaseInserterTest(TestCase):
@@ -28,18 +29,18 @@ class BaseInserterTest(TestCase):
         with patch("RatS.base.base_site.Site") as site_mock:
             inserter = RatingsInserter(site_mock, None)
 
-        movie = dict()
-        movie["title"] = "Fight Club"
-        movie["year"] = 1999
-        movie["imdb"] = dict()
-        movie["imdb"]["id"] = "tt0137523"
-        movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie["imdb"]["my_rating"] = 9
+        movie = Movie()
+        movie.title = "Fight Club"
+        movie.year = 1999
+        movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie.site_data[Site.IMDB].id = "tt0137523"
+        movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        movie.site_data[Site.IMDB]["my_rating"] = 9
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "unreadable movie"
         movie2["year"] = 1111
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "xxx"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/xxx"
         movie2["imdb"]["my_rating"] = 4
@@ -47,7 +48,7 @@ class BaseInserterTest(TestCase):
         movies = [movie, movie, movie2]
         search_success_mock.side_effect = [True, True, False]
 
-        inserter.insert(movies, "imdb")
+        inserter.insert(movies, Site.IMDB)
 
         self.assertEqual(1, len(inserter.failed_movies))
         save_movies_to_json_mock.assert_called_with(
@@ -72,18 +73,18 @@ class BaseInserterTest(TestCase):
         with patch("RatS.base.base_site.Site") as site_mock:
             inserter = RatingsInserter(site_mock, None)
 
-        movie = dict()
-        movie["title"] = "Fight Club"
-        movie["year"] = 1999
-        movie["imdb"] = dict()
-        movie["imdb"]["id"] = "tt0137523"
-        movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie["imdb"]["my_rating"] = 9
+        movie = Movie()
+        movie.title = "Fight Club"
+        movie.year = 1999
+        movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie.site_data[Site.IMDB].id = "tt0137523"
+        movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        movie.site_data[Site.IMDB]["my_rating"] = 9
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "unreadable movie"
         movie2["year"] = 1111
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "xxx"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/xxx"
         movie2["imdb"]["my_rating"] = 4

--- a/tests/unit/base/test_base_ratings_inserter.py
+++ b/tests/unit/base/test_base_ratings_inserter.py
@@ -29,21 +29,15 @@ class BaseInserterTest(TestCase):
         with patch("RatS.base.base_site.BaseSite") as site_mock:
             inserter = RatingsInserter(site_mock, None)
 
-        movie = Movie()
-        movie.title = "Fight Club"
-        movie.year = 1999
-        movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie.site_data[Site.IMDB].id = "tt0137523"
-        movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie.site_data[Site.IMDB].my_rating = 9
+        movie = Movie(title="Fight Club", year=1999)
+        movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523", url="https://www.imdb.com/title/tt0137523", my_rating=9
+        )
 
-        movie2 = Movie()
-        movie2.title = "unreadable movie"
-        movie2.year = 1111
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "xxx"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/xxx"
-        movie2.site_data[Site.IMDB].my_rating = 4
+        movie2 = Movie(title="unreadable movie", year=1111)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="xxx", url="https://www.imdb.com/title/xxx", my_rating=4
+        )
 
         movies = [movie, movie, movie2]
         search_success_mock.side_effect = [True, True, False]
@@ -73,21 +67,15 @@ class BaseInserterTest(TestCase):
         with patch("RatS.base.base_site.BaseSite") as site_mock:
             inserter = RatingsInserter(site_mock, None)
 
-        movie = Movie()
-        movie.title = "Fight Club"
-        movie.year = 1999
-        movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie.site_data[Site.IMDB].id = "tt0137523"
-        movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie.site_data[Site.IMDB].my_rating = 9
+        movie = Movie(title="Fight Club", year=1999)
+        movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523", url="https://www.imdb.com/title/tt0137523", my_rating=9
+        )
 
-        movie2 = Movie()
-        movie2.title = "unreadable movie"
-        movie2.year = 1111
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "xxx"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/xxx"
-        movie2.site_data[Site.IMDB].my_rating = 4
+        movie2 = Movie(title="unreadable movie", year=1111)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="xxx", url="https://www.imdb.com/title/xxx", my_rating=4
+        )
 
         movies = [movie, movie2, movie2]
         search_success_mock.side_effect = [True, False, False]

--- a/tests/unit/base/test_base_ratings_inserter.py
+++ b/tests/unit/base/test_base_ratings_inserter.py
@@ -34,16 +34,16 @@ class BaseInserterTest(TestCase):
         movie.year = 1999
         movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         movie.site_data[Site.IMDB].id = "tt0137523"
-        movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie.site_data[Site.IMDB]["my_rating"] = 9
+        movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie.site_data[Site.IMDB].my_rating = 9
 
         movie2 = Movie()
-        movie2["title"] = "unreadable movie"
-        movie2["year"] = 1111
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "xxx"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/xxx"
-        movie2["imdb"]["my_rating"] = 4
+        movie2.title = "unreadable movie"
+        movie2.year = 1111
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "xxx"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/xxx"
+        movie2.site_data[Site.IMDB].my_rating = 4
 
         movies = [movie, movie, movie2]
         search_success_mock.side_effect = [True, True, False]
@@ -78,21 +78,21 @@ class BaseInserterTest(TestCase):
         movie.year = 1999
         movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         movie.site_data[Site.IMDB].id = "tt0137523"
-        movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie.site_data[Site.IMDB]["my_rating"] = 9
+        movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie.site_data[Site.IMDB].my_rating = 9
 
         movie2 = Movie()
-        movie2["title"] = "unreadable movie"
-        movie2["year"] = 1111
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "xxx"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/xxx"
-        movie2["imdb"]["my_rating"] = 4
+        movie2.title = "unreadable movie"
+        movie2.year = 1111
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "xxx"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/xxx"
+        movie2.site_data[Site.IMDB].my_rating = 4
 
         movies = [movie, movie2, movie2]
         search_success_mock.side_effect = [True, False, False]
 
-        inserter.insert(movies, "imdb")
+        inserter.insert(movies, Site.IMDB)
 
         self.assertEqual(2, len(inserter.failed_movies))
         save_movies_to_json_mock.assert_called_with(

--- a/tests/unit/base/test_base_ratings_inserter.py
+++ b/tests/unit/base/test_base_ratings_inserter.py
@@ -8,7 +8,7 @@ from RatS.base.movie_entity import Site, SiteSpecificMovieData, Movie
 class BaseInserterTest(TestCase):
     @patch("RatS.utils.browser_handler.Firefox")
     def test_init(self, browser_mock):
-        with patch("RatS.base.base_site.Site") as site_mock:
+        with patch("RatS.base.base_site.BaseSite") as site_mock:
             inserter = RatingsInserter(site_mock, None)
 
             self.assertEqual(inserter.site, site_mock)
@@ -26,7 +26,7 @@ class BaseInserterTest(TestCase):
         progress_bar_mock,
         save_movies_to_json_mock,
     ):
-        with patch("RatS.base.base_site.Site") as site_mock:
+        with patch("RatS.base.base_site.BaseSite") as site_mock:
             inserter = RatingsInserter(site_mock, None)
 
         movie = Movie()
@@ -70,7 +70,7 @@ class BaseInserterTest(TestCase):
         progress_bar_mock,
         save_movies_to_json_mock,
     ):
-        with patch("RatS.base.base_site.Site") as site_mock:
+        with patch("RatS.base.base_site.BaseSite") as site_mock:
             inserter = RatingsInserter(site_mock, None)
 
         movie = Movie()

--- a/tests/unit/base/test_base_ratings_parser.py
+++ b/tests/unit/base/test_base_ratings_parser.py
@@ -7,7 +7,7 @@ from RatS.base.base_ratings_parser import RatingsParser
 class BaseParserTest(TestCase):
     @patch("RatS.utils.browser_handler.Firefox")
     def test_init(self, browser_mock):
-        with patch("RatS.base.base_site.Site") as site_mock:
+        with patch("RatS.base.base_site.BaseSite") as site_mock:
             parser = RatingsParser(site_mock, None)
 
             self.assertEqual(parser.site, site_mock)

--- a/tests/unit/criticker/test_criticker_ratings_inserter.py
+++ b/tests/unit/criticker/test_criticker_ratings_inserter.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
+from RatS.base.movie_entity import Site
 from RatS.criticker.criticker_ratings_inserter import CritickerRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -15,14 +16,14 @@ class CritickerRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
-        self.movie["tmdb"] = dict()
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie["tmdb"] = SiteSpecificMovieData()
         self.movie["tmdb"]["id"] = "550"
         self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
         with open(
@@ -94,7 +95,7 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         result = inserter._compare_external_links(
-            self.movie_details_page, self.movie, "imdb.com", "imdb"
+            self.movie_details_page, self.movie, "imdb.com", Site.IMDB
         )  # pylint: disable=protected-access
 
         self.assertTrue(result)
@@ -111,16 +112,16 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.site.site_name = "Criticker"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Arrival"
         movie2["year"] = 2006
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt2543164"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt2543164"
         movie2["imdb"]["my_rating"] = 7
 
         result = inserter._compare_external_links(
-            self.movie_details_page, movie2, "imdb.com", "imdb"
+            self.movie_details_page, movie2, "imdb.com", Site.IMDB
         )  # pylint: disable=protected-access
 
         self.assertFalse(result)
@@ -163,7 +164,7 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         compare_mock.return_value = True
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -191,7 +192,7 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         compare_mock.return_value = True
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1998
 
@@ -233,10 +234,10 @@ class CritickerRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9

--- a/tests/unit/criticker/test_criticker_ratings_inserter.py
+++ b/tests/unit/criticker/test_criticker_ratings_inserter.py
@@ -16,16 +16,16 @@ class CritickerRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
-        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.TMDB].id = "550"
-        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="550",
+            url="https://www.themoviedb.org/movie/550",
+        )
         with open(
             os.path.join(TESTDATA_PATH, "criticker", "search_result.html"),
             encoding="UTF-8",
@@ -112,13 +112,12 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.site.site_name = "Criticker"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Arrival"
-        movie2.year = 2006
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt2543164"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt2543164"
-        movie2.site_data[Site.IMDB].my_rating = 7
+        movie2 = Movie(title="Arrival", year=2006)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt2543164",
+            url="https://www.imdb.com/title/tt2543164",
+            my_rating=7,
+        )
 
         result = inserter._compare_external_links(
             self.movie_details_page, movie2, "imdb.com", Site.IMDB
@@ -164,9 +163,7 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         compare_mock.return_value = True
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -192,9 +189,7 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         compare_mock.return_value = True
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1998
+        movie2 = Movie(title="Fight Club", year=1998)
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -234,13 +229,12 @@ class CritickerRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="Fight Club", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/criticker/test_criticker_ratings_inserter.py
+++ b/tests/unit/criticker/test_criticker_ratings_inserter.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
-from RatS.base.movie_entity import Site
+from RatS.base.movie_entity import Site, Movie, SiteSpecificMovieData
 from RatS.criticker.criticker_ratings_inserter import CritickerRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -21,11 +21,11 @@ class CritickerRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
-        self.movie["tmdb"] = SiteSpecificMovieData()
-        self.movie["tmdb"]["id"] = "550"
-        self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.TMDB].id = "550"
+        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
         with open(
             os.path.join(TESTDATA_PATH, "criticker", "search_result.html"),
             encoding="UTF-8",
@@ -77,7 +77,7 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.site.site_name = "Criticker"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -113,12 +113,12 @@ class CritickerRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Arrival"
-        movie2["year"] = 2006
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt2543164"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt2543164"
-        movie2["imdb"]["my_rating"] = 7
+        movie2.title = "Arrival"
+        movie2.year = 2006
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt2543164"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt2543164"
+        movie2.site_data[Site.IMDB].my_rating = 7
 
         result = inserter._compare_external_links(
             self.movie_details_page, movie2, "imdb.com", Site.IMDB
@@ -165,8 +165,8 @@ class CritickerRatingsInserterTest(TestCase):
         compare_mock.return_value = True
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -193,8 +193,8 @@ class CritickerRatingsInserterTest(TestCase):
         compare_mock.return_value = True
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1998
+        movie2.title = "Fight Club"
+        movie2.year = 1998
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -235,12 +235,12 @@ class CritickerRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/criticker/test_criticker_ratings_parser.py
+++ b/tests/unit/criticker/test_criticker_ratings_parser.py
@@ -43,7 +43,9 @@ class CritickerParserTest(TestCase):
 
         self.assertEqual(1531, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.CRITICKER]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.CRITICKER])
+        )
         self.assertEqual("Fight Club", parser.movies[0].title)
         self.assertEqual(1999, parser.movies[0].year)
         self.assertEqual("1077", parser.movies[0].site_data[Site.CRITICKER].id)
@@ -52,10 +54,13 @@ class CritickerParserTest(TestCase):
             parser.movies[0].site_data[Site.CRITICKER].url,
         )
         self.assertEqual(10, parser.movies[0].site_data[Site.CRITICKER].my_rating)
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.CRITICKER]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.CRITICKER])
+        )
         self.assertEqual("tt0137523", parser.movies[0].site_data[Site.IMDB].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0137523", parser.movies[0].site_data[Site.IMDB].url
+            "https://www.imdb.com/title/tt0137523",
+            parser.movies[0].site_data[Site.IMDB].url,
         )
 
         os.remove(os.path.join(TESTDATA_PATH, "exports", parser.xml_filename))

--- a/tests/unit/criticker/test_criticker_ratings_parser.py
+++ b/tests/unit/criticker/test_criticker_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.criticker.criticker_ratings_parser import CritickerRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -33,6 +34,7 @@ class CritickerParserTest(TestCase):
         parser = CritickerRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.CRITICKER
         parser.site.site_name = "Criticker"
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))
@@ -40,18 +42,20 @@ class CritickerParserTest(TestCase):
         parser.parse()
 
         self.assertEqual(1531, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Fight Club", parser.movies[0]["title"])
-        self.assertEqual(1999, parser.movies[0]["year"])
-        self.assertEqual("1077", parser.movies[0]["criticker"]["id"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.CRITICKER]))
+        self.assertEqual("Fight Club", parser.movies[0].title)
+        self.assertEqual(1999, parser.movies[0].year)
+        self.assertEqual("1077", parser.movies[0].site_data[Site.CRITICKER].id)
         self.assertEqual(
             "https://www.criticker.com/film/Fight-Club",
-            parser.movies[0]["criticker"]["url"],
+            parser.movies[0].site_data[Site.CRITICKER].url,
         )
-        self.assertEqual(10, parser.movies[0]["criticker"]["my_rating"])
-        self.assertEqual("tt0137523", parser.movies[0]["imdb"]["id"])
+        self.assertEqual(10, parser.movies[0].site_data[Site.CRITICKER].my_rating)
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.CRITICKER]))
+        self.assertEqual("tt0137523", parser.movies[0].site_data[Site.CRITICKER].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0137523", parser.movies[0]["imdb"]["url"]
+            "https://www.imdb.com/title/tt0137523", parser.movies[0].site_data[Site.CRITICKER].url
         )
 
         os.remove(os.path.join(TESTDATA_PATH, "exports", parser.xml_filename))

--- a/tests/unit/criticker/test_criticker_ratings_parser.py
+++ b/tests/unit/criticker/test_criticker_ratings_parser.py
@@ -53,9 +53,9 @@ class CritickerParserTest(TestCase):
         )
         self.assertEqual(10, parser.movies[0].site_data[Site.CRITICKER].my_rating)
         self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.CRITICKER]))
-        self.assertEqual("tt0137523", parser.movies[0].site_data[Site.CRITICKER].id)
+        self.assertEqual("tt0137523", parser.movies[0].site_data[Site.IMDB].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0137523", parser.movies[0].site_data[Site.CRITICKER].url
+            "https://www.imdb.com/title/tt0137523", parser.movies[0].site_data[Site.IMDB].url
         )
 
         os.remove(os.path.join(TESTDATA_PATH, "exports", parser.xml_filename))

--- a/tests/unit/filmaffinity/test_filmaffinity_ratings_inserter.py
+++ b/tests/unit/filmaffinity/test_filmaffinity_ratings_inserter.py
@@ -14,13 +14,12 @@ class FilmAffinityRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Ghost in the Shell"
-        self.movie.year = 1995
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0113568"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0113568"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Ghost in the Shell", year=1995)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0113568",
+            url="https://www.imdb.com/title/tt0113568",
+            my_rating=9,
+        )
         with open(
             os.path.join(TESTDATA_PATH, "filmaffinity", "search_result.html"),
             encoding="UTF-8",
@@ -99,9 +98,7 @@ class FilmAffinityRatingsInserterTest(TestCase):
         inserter.site.site_name = "FilmAffinity"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Ghost in the Shell"
-        movie2.year = 1995
+        movie2 = Movie(title="Ghost in the Shell", year=1995)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -138,9 +135,7 @@ class FilmAffinityRatingsInserterTest(TestCase):
         inserter.site.site_name = "FilmAffinity"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Ghost in the Shell"
-        movie2.year = 1995
+        movie2 = Movie(title="Ghost in the Shell", year=1995)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -167,13 +162,10 @@ class FilmAffinityRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="The Matrix", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523", url="https://www.imdb.com/title/tt0137523", my_rating=9
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/filmaffinity/test_filmaffinity_ratings_inserter.py
+++ b/tests/unit/filmaffinity/test_filmaffinity_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData, Site
 from RatS.filmaffinity.filmaffinity_ratings_inserter import FilmAffinityRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -18,8 +19,8 @@ class FilmAffinityRatingsInserterTest(TestCase):
         self.movie.year = 1995
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0113568"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0113568"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0113568"
+        self.movie.site_data[Site.IMDB].my_rating = 9
         with open(
             os.path.join(TESTDATA_PATH, "filmaffinity", "search_result.html"),
             encoding="UTF-8",
@@ -76,7 +77,7 @@ class FilmAffinityRatingsInserterTest(TestCase):
         inserter.site.site_name = "FilmAffinity"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -99,8 +100,8 @@ class FilmAffinityRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Ghost in the Shell"
-        movie2["year"] = 1995
+        movie2.title = "Ghost in the Shell"
+        movie2.year = 1995
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -138,8 +139,8 @@ class FilmAffinityRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Ghost in the Shell"
-        movie2["year"] = 1995
+        movie2.title = "Ghost in the Shell"
+        movie2.year = 1995
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -167,12 +168,12 @@ class FilmAffinityRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/filmaffinity/test_filmaffinity_ratings_inserter.py
+++ b/tests/unit/filmaffinity/test_filmaffinity_ratings_inserter.py
@@ -13,13 +13,13 @@ class FilmAffinityRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Ghost in the Shell"
-        self.movie["year"] = 1995
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0113568"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0113568"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Ghost in the Shell"
+        self.movie.year = 1995
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0113568"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0113568"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
         with open(
             os.path.join(TESTDATA_PATH, "filmaffinity", "search_result.html"),
             encoding="UTF-8",
@@ -98,7 +98,7 @@ class FilmAffinityRatingsInserterTest(TestCase):
         inserter.site.site_name = "FilmAffinity"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Ghost in the Shell"
         movie2["year"] = 1995
 
@@ -137,7 +137,7 @@ class FilmAffinityRatingsInserterTest(TestCase):
         inserter.site.site_name = "FilmAffinity"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Ghost in the Shell"
         movie2["year"] = 1995
 
@@ -166,10 +166,10 @@ class FilmAffinityRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9

--- a/tests/unit/filmaffinity/test_filmaffinity_ratings_parser.py
+++ b/tests/unit/filmaffinity/test_filmaffinity_ratings_parser.py
@@ -48,7 +48,9 @@ class FilmAffinityRatingsParserTest(TestCase):
 
         self.assertEqual(20, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.FILMAFFINITY]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.FILMAFFINITY])
+        )
         self.assertEqual("Vollidiot", parser.movies[0].title)
         self.assertEqual("125089", parser.movies[0].site_data[Site.FILMAFFINITY].id)
         self.assertEqual(

--- a/tests/unit/filmaffinity/test_filmaffinity_ratings_parser.py
+++ b/tests/unit/filmaffinity/test_filmaffinity_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Site, Movie, SiteSpecificMovieData
 from RatS.filmaffinity.filmaffinity_ratings_parser import FilmAffinityRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -38,6 +39,7 @@ class FilmAffinityRatingsParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.FILMAFFINITY
         parser.site.site_name = "FilmAffinity"
         parser.site.browser = browser_mock
         parser.args = None
@@ -45,12 +47,13 @@ class FilmAffinityRatingsParserTest(TestCase):
         parser.parse()
 
         self.assertEqual(20, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Vollidiot", parser.movies[0]["title"])
-        self.assertEqual("125089", parser.movies[0]["filmaffinity"]["id"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.FILMAFFINITY]))
+        self.assertEqual("Vollidiot", parser.movies[0].title)
+        self.assertEqual("125089", parser.movies[0].site_data[Site.FILMAFFINITY].id)
         self.assertEqual(
             "https://www.filmaffinity.com/us/film125089.html",
-            parser.movies[0]["filmaffinity"]["url"],
+            parser.movies[0].site_data[Site.FILMAFFINITY].url,
         )
-        self.assertEqual(2007, parser.movies[0]["year"])
-        self.assertEqual(7, parser.movies[0]["filmaffinity"]["my_rating"])
+        self.assertEqual(2007, parser.movies[0].year)
+        self.assertEqual(7, parser.movies[0].site_data[Site.FILMAFFINITY].my_rating)

--- a/tests/unit/filmtipset/test_filmtipset_ratings_inserter.py
+++ b/tests/unit/filmtipset/test_filmtipset_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.filmtipset.filmtipset_ratings_inserter import FilmtipsetRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -18,8 +19,8 @@ class FilmtipsetRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
         with open(
             os.path.join(TESTDATA_PATH, "filmtipset", "search_result.html"),
             encoding="UTF-8",
@@ -71,7 +72,7 @@ class FilmtipsetRatingsInserterTest(TestCase):
         inserter.site.site_name = "Filmtipset"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -105,8 +106,8 @@ class FilmtipsetRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -134,12 +135,12 @@ class FilmtipsetRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/filmtipset/test_filmtipset_ratings_inserter.py
+++ b/tests/unit/filmtipset/test_filmtipset_ratings_inserter.py
@@ -14,13 +14,10 @@ class FilmtipsetRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523", url="https://www.imdb.com/title/tt0137523", my_rating=9
+        )
         with open(
             os.path.join(TESTDATA_PATH, "filmtipset", "search_result.html"),
             encoding="UTF-8",
@@ -105,9 +102,7 @@ class FilmtipsetRatingsInserterTest(TestCase):
         inserter.site.site_name = "Filmtipset"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -134,13 +129,10 @@ class FilmtipsetRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="Fight Club", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523", url="https://www.imdb.com/title/tt0137523", my_rating=9
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/filmtipset/test_filmtipset_ratings_inserter.py
+++ b/tests/unit/filmtipset/test_filmtipset_ratings_inserter.py
@@ -13,13 +13,13 @@ class FilmtipsetRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
         with open(
             os.path.join(TESTDATA_PATH, "filmtipset", "search_result.html"),
             encoding="UTF-8",
@@ -104,7 +104,7 @@ class FilmtipsetRatingsInserterTest(TestCase):
         inserter.site.site_name = "Filmtipset"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -133,10 +133,10 @@ class FilmtipsetRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9

--- a/tests/unit/filmtipset/test_filmtipset_ratings_parser.py
+++ b/tests/unit/filmtipset/test_filmtipset_ratings_parser.py
@@ -139,7 +139,7 @@ class FilmtipetParserTest(TestCase):
             headers, row
         )  # pylint: disable=protected-access
         self.assertEqual(1, imdb_mock.call_count)
-        self.assertEqual(movie, expected_movie)
+        self.assertDictEqual(movie.__dict__, expected_movie.__dict__)
 
     def test_extract_imdb_information(self):
         tests = [

--- a/tests/unit/filmtipset/test_filmtipset_ratings_parser.py
+++ b/tests/unit/filmtipset/test_filmtipset_ratings_parser.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 from shutil import copyfile
 
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData, Site
 from RatS.filmtipset.filmtipset_ratings_parser import FilmtipsetRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -123,50 +124,48 @@ class FilmtipetParserTest(TestCase):
         parser = FilmtipsetRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.FILMTIPSET
         parser.site.site_name = "Filmtipset"
         parser.site.browser = browser_mock
 
-        expected_movie = {
-            "title": "Hunt for the Wilderpeople",
-            "filmtipset": {"my_rating": 10},
-        }
+        expected_site_date = SiteSpecificMovieData()
+        expected_site_date.my_rating = 10
+        expected_movie = Movie()
+        expected_movie.title = "Hunt for the Wilderpeople"
+        expected_movie.site_data[Site.FILMTIPSET] = expected_site_date
         headers = ["VoteDate", "MovieTitle", "IMDB", "Score"]
         row = ["2020-10-10", "Hunt for the Wilderpeople", "4698684", "5"]
         movie = parser._convert_csv_row_to_movie(
             headers, row
         )  # pylint: disable=protected-access
         self.assertEqual(1, imdb_mock.call_count)
-        self.assertDictEqual(movie, expected_movie)
+        self.assertEqual(movie, expected_movie)
 
     def test_extract_imdb_information(self):
         tests = [
             (
                 "1234567",
                 {
-                    "imdb": {
-                        "id": "tt1234567",
-                        "url": "https://www.imdb.com/title/tt1234567",
-                    }
-                },
+                    "id": "tt1234567",
+                    "url": "https://www.imdb.com/title/tt1234567",
+                }
             ),
             (
                 "12345",
                 {
-                    "imdb": {
-                        "id": "tt0012345",
-                        "url": "https://www.imdb.com/title/tt0012345",
-                    }
-                },
+                    "id": "tt0012345",
+                    "url": "https://www.imdb.com/title/tt0012345",
+                }
             ),
-            ("", {}),
         ]
         for test in tests:
             movie = Movie()
-            num, expected_movie = test
+            num, expected_movie_details = test
             FilmtipsetRatingsParser._extract_imdb_information(
                 movie, num
             )  # pylint: disable=protected-access
-            self.assertDictEqual(movie, expected_movie)
+            self.assertEqual(movie.site_data[Site.IMDB].id, expected_movie_details['id'])
+            self.assertEqual(movie.site_data[Site.IMDB].url, expected_movie_details['url'])
 
     @patch("RatS.base.base_ratings_parser.RatingsParser.__init__")
     @patch("RatS.utils.browser_handler.Firefox")

--- a/tests/unit/filmtipset/test_filmtipset_ratings_parser.py
+++ b/tests/unit/filmtipset/test_filmtipset_ratings_parser.py
@@ -128,11 +128,8 @@ class FilmtipetParserTest(TestCase):
         parser.site.site_name = "Filmtipset"
         parser.site.browser = browser_mock
 
-        expected_site_date = SiteSpecificMovieData()
-        expected_site_date.my_rating = 10
-        expected_movie = Movie()
-        expected_movie.title = "Hunt for the Wilderpeople"
-        expected_movie.site_data[Site.FILMTIPSET] = expected_site_date
+        expected_movie = Movie(title="Hunt for the Wilderpeople")
+        expected_movie.site_data[Site.FILMTIPSET] = SiteSpecificMovieData(my_rating=10)
         headers = ["VoteDate", "MovieTitle", "IMDB", "Score"]
         row = ["2020-10-10", "Hunt for the Wilderpeople", "4698684", "5"]
         movie = parser._convert_csv_row_to_movie(
@@ -148,14 +145,14 @@ class FilmtipetParserTest(TestCase):
                 {
                     "id": "tt1234567",
                     "url": "https://www.imdb.com/title/tt1234567",
-                }
+                },
             ),
             (
                 "12345",
                 {
                     "id": "tt0012345",
                     "url": "https://www.imdb.com/title/tt0012345",
-                }
+                },
             ),
         ]
         for test in tests:
@@ -164,8 +161,12 @@ class FilmtipetParserTest(TestCase):
             FilmtipsetRatingsParser._extract_imdb_information(
                 movie, num
             )  # pylint: disable=protected-access
-            self.assertEqual(movie.site_data[Site.IMDB].id, expected_movie_details['id'])
-            self.assertEqual(movie.site_data[Site.IMDB].url, expected_movie_details['url'])
+            self.assertEqual(
+                expected_movie_details["id"], movie.site_data[Site.IMDB].id
+            )
+            self.assertEqual(
+                expected_movie_details["url"], movie.site_data[Site.IMDB].url
+            )
 
     @patch("RatS.base.base_ratings_parser.RatingsParser.__init__")
     @patch("RatS.utils.browser_handler.Firefox")

--- a/tests/unit/filmtipset/test_filmtipset_ratings_parser.py
+++ b/tests/unit/filmtipset/test_filmtipset_ratings_parser.py
@@ -161,7 +161,7 @@ class FilmtipetParserTest(TestCase):
             ("", {}),
         ]
         for test in tests:
-            movie = dict()
+            movie = Movie()
             num, expected_movie = test
             FilmtipsetRatingsParser._extract_imdb_information(
                 movie, num

--- a/tests/unit/flixster/test_flixster_ratings_inserter.py
+++ b/tests/unit/flixster/test_flixster_ratings_inserter.py
@@ -13,14 +13,14 @@ class FlixsterRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
-        self.movie["tmdb"] = dict()
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie["tmdb"] = SiteSpecificMovieData()
         self.movie["tmdb"]["id"] = "550"
         self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
         with open(
@@ -90,10 +90,10 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.site.site_name = "Flixster"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
-        movie2["flixster"] = dict()
+        movie2["flixster"] = SiteSpecificMovieData()
         movie2["flixster"]["url"] = "https://www.flixster.com/movie/fight-club/"
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
@@ -113,7 +113,7 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.site.site_name = "Flixster"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -142,10 +142,10 @@ class FlixsterRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9
@@ -171,7 +171,7 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         search_mock.return_value = True
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -200,7 +200,7 @@ class FlixsterRatingsInserterTest(TestCase):
         search_mock.return_value = False
         empty_result_mock.return_value = True
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Not A Movie"
         movie2["year"] = 1999
 

--- a/tests/unit/flixster/test_flixster_ratings_inserter.py
+++ b/tests/unit/flixster/test_flixster_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.flixster.flixster_ratings_inserter import FlixsterRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -18,11 +19,11 @@ class FlixsterRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
-        self.movie["tmdb"] = SiteSpecificMovieData()
-        self.movie["tmdb"]["id"] = "550"
-        self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.TMDB].id = "550"
+        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
         with open(
             os.path.join(TESTDATA_PATH, "flixster", "search_result.html"),
             encoding="ISO-8859-1",
@@ -74,7 +75,7 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.site.site_name = "Flixster"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -91,10 +92,11 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
-        movie2["flixster"] = SiteSpecificMovieData()
-        movie2["flixster"]["url"] = "https://www.flixster.com/movie/fight-club/"
+        movie2.title = "Fight Club"
+        movie2.year = 1999
+        movie2.site_data = dict()
+        movie2.site_data[Site.FLIXSTER] = SiteSpecificMovieData()
+        movie2.site_data[Site.FLIXSTER].url = "https://www.flixster.com/movie/fight-club/"
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -114,8 +116,8 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -143,12 +145,13 @@ class FlixsterRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data = dict()
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -172,8 +175,8 @@ class FlixsterRatingsInserterTest(TestCase):
         search_mock.return_value = True
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -201,8 +204,8 @@ class FlixsterRatingsInserterTest(TestCase):
         empty_result_mock.return_value = True
 
         movie2 = Movie()
-        movie2["title"] = "Not A Movie"
-        movie2["year"] = 1999
+        movie2.title = "Not A Movie"
+        movie2.year = 1999
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/flixster/test_flixster_ratings_inserter.py
+++ b/tests/unit/flixster/test_flixster_ratings_inserter.py
@@ -14,16 +14,16 @@ class FlixsterRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
-        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.TMDB].id = "550"
-        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="550",
+            url="https://www.themoviedb.org/movie/550",
+        )
         with open(
             os.path.join(TESTDATA_PATH, "flixster", "search_result.html"),
             encoding="ISO-8859-1",
@@ -91,12 +91,10 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.site.site_name = "Flixster"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
-        movie2.site_data = dict()
-        movie2.site_data[Site.FLIXSTER] = SiteSpecificMovieData()
-        movie2.site_data[Site.FLIXSTER].url = "https://www.flixster.com/movie/fight-club/"
+        movie2 = Movie(title="Fight Club", year=1999)
+        movie2.site_data[Site.FLIXSTER] = SiteSpecificMovieData(
+            url="https://www.flixster.com/movie/fight-club/"
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -115,9 +113,7 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.site.site_name = "Flixster"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -144,14 +140,12 @@ class FlixsterRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data = dict()
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="The Matrix", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -174,9 +168,7 @@ class FlixsterRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         search_mock.return_value = True
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -203,9 +195,7 @@ class FlixsterRatingsInserterTest(TestCase):
         search_mock.return_value = False
         empty_result_mock.return_value = True
 
-        movie2 = Movie()
-        movie2.title = "Not A Movie"
-        movie2.year = 1999
+        movie2 = Movie(title="Not A Movie", year=1999)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/flixster/test_flixster_ratings_parser.py
+++ b/tests/unit/flixster/test_flixster_ratings_parser.py
@@ -3,6 +3,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Site, Movie, SiteSpecificMovieData
 from RatS.flixster.flixster_ratings_parser import FlixsterRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -39,19 +40,21 @@ class FlixsterParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.FLIXSTER
         parser.site.site_name = "Flixster"
         parser.site.browser = browser_mock
 
         parser.parse()
 
         self.assertEqual(330 - 9, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Fight Club", parser.movies[0]["title"])
-        self.assertEqual(1999, parser.movies[0]["year"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.FLIXSTER]))
+        self.assertEqual("Fight Club", parser.movies[0].title)
+        self.assertEqual(1999, parser.movies[0].year)
 
-        self.assertEqual(13153, parser.movies[0]["flixster"]["id"])
+        self.assertEqual(13153, parser.movies[0].site_data[Site.FLIXSTER].id)
         self.assertEqual(
             "https://www.flixster.com/movie/fight-club/",
-            parser.movies[0]["flixster"]["url"],
+            parser.movies[0].site_data[Site.FLIXSTER].url,
         )
-        self.assertEqual(10, parser.movies[0]["flixster"]["my_rating"])
+        self.assertEqual(10, parser.movies[0].site_data[Site.FLIXSTER].my_rating)

--- a/tests/unit/flixster/test_flixster_ratings_parser.py
+++ b/tests/unit/flixster/test_flixster_ratings_parser.py
@@ -48,11 +48,13 @@ class FlixsterParserTest(TestCase):
 
         self.assertEqual(330 - 9, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.FLIXSTER]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.FLIXSTER])
+        )
         self.assertEqual("Fight Club", parser.movies[0].title)
         self.assertEqual(1999, parser.movies[0].year)
 
-        self.assertEqual(13153, parser.movies[0].site_data[Site.FLIXSTER].id)
+        self.assertEqual("13153", parser.movies[0].site_data[Site.FLIXSTER].id)
         self.assertEqual(
             "https://www.flixster.com/movie/fight-club/",
             parser.movies[0].site_data[Site.FLIXSTER].url,

--- a/tests/unit/icheckmovies/test_icheckmovies_ratings_inserter.py
+++ b/tests/unit/icheckmovies/test_icheckmovies_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData, Site
 from RatS.icheckmovies.icheckmovies_ratings_inserter import ICheckMoviesRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -17,8 +18,8 @@ class ICheckMoviesInserterTest(TestCase):
         self.movie.title = "Fight Club"
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
 
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")
     @patch("RatS.utils.browser_handler.Firefox")
@@ -43,7 +44,7 @@ class ICheckMoviesInserterTest(TestCase):
         inserter.exports_folder = TESTDATA_PATH
         inserter.csv_filename = "converted.csv"
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(impex_mock.called)

--- a/tests/unit/icheckmovies/test_icheckmovies_ratings_inserter.py
+++ b/tests/unit/icheckmovies/test_icheckmovies_ratings_inserter.py
@@ -14,12 +14,12 @@ class ICheckMoviesInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Fight Club")
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")
     @patch("RatS.utils.browser_handler.Firefox")

--- a/tests/unit/icheckmovies/test_icheckmovies_ratings_inserter.py
+++ b/tests/unit/icheckmovies/test_icheckmovies_ratings_inserter.py
@@ -13,12 +13,12 @@ class ICheckMoviesInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
 
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")
     @patch("RatS.utils.browser_handler.Firefox")

--- a/tests/unit/icheckmovies/test_icheckmovies_ratings_parser.py
+++ b/tests/unit/icheckmovies/test_icheckmovies_ratings_parser.py
@@ -74,6 +74,7 @@ class ICheckMoviesParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.ICHECKMOVIES
         parser.site.site_name = "ICheckMovies"
         parser.site.browser = browser_mock
         parser.args = None
@@ -84,20 +85,20 @@ class ICheckMoviesParserTest(TestCase):
 
         self.assertEqual(240, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
         self.assertEqual("Fight Club", parser.movies[0].title)
-        self.assertEqual("21", parser.movies[0].site_data[parser.site.site].id)
+        self.assertEqual("21", parser.movies[0].site_data[Site.ICHECKMOVIES].id)
         self.assertEqual(
             "https://www.icheckmovies.com/movies/fight+club/",
-            parser.movies[0].site_data[parser.site.site].url,
+            parser.movies[0].site_data[Site.ICHECKMOVIES].url,
         )
         self.assertEqual(1999, parser.movies[0].year)
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
-        self.assertEqual("tt0137523", parser.movies[0].site_data[parser.site.site].id)
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
+        self.assertEqual("tt0137523", parser.movies[0].site_data[Site.ICHECKMOVIES].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0137523", parser.movies[0].site_data[parser.site.site].url
+            "https://www.imdb.com/title/tt0137523", parser.movies[0].site_data[Site.ICHECKMOVIES].url
         )
-        self.assertEqual(8, parser.movies[0].site_data[parser.site.site].my_rating)
+        self.assertEqual(8, parser.movies[0].site_data[Site.ICHECKMOVIES].my_rating)
 
     @patch("RatS.base.base_ratings_parser.RatingsParser._print_progress_bar")
     @patch("RatS.utils.browser_handler.Firefox")
@@ -133,8 +134,8 @@ class ICheckMoviesParserTest(TestCase):
         )
         self.assertEqual(2004, parser.movies[0].year)
         self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
-        self.assertEqual("tt0421051", parser.movies[0].site_data[Site.ICHECKMOVIES].id)
+        self.assertEqual("tt0421051", parser.movies[0].site_data[Site.IMDB].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0421051", parser.movies[0].site_data[Site.ICHECKMOVIES].url
+            "https://www.imdb.com/title/tt0421051", parser.movies[0].site_data[Site.IMDB].url
         )
         self.assertEqual(3, parser.movies[0].site_data[Site.ICHECKMOVIES].my_rating)

--- a/tests/unit/icheckmovies/test_icheckmovies_ratings_parser.py
+++ b/tests/unit/icheckmovies/test_icheckmovies_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Site, Movie, SiteSpecificMovieData
 from RatS.icheckmovies.icheckmovies_ratings_parser import ICheckMoviesRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -82,19 +83,21 @@ class ICheckMoviesParserTest(TestCase):
         )  # pylint: disable=protected-access
 
         self.assertEqual(240, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Fight Club", parser.movies[0]["title"])
-        self.assertEqual("21", parser.movies[0]["icheckmovies"]["id"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
+        self.assertEqual("Fight Club", parser.movies[0].title)
+        self.assertEqual("21", parser.movies[0].site_data[parser.site.site].id)
         self.assertEqual(
             "https://www.icheckmovies.com/movies/fight+club/",
-            parser.movies[0]["icheckmovies"]["url"],
+            parser.movies[0].site_data[parser.site.site].url,
         )
-        self.assertEqual(1999, parser.movies[0]["year"])
-        self.assertEqual("tt0137523", parser.movies[0]["imdb"]["id"])
+        self.assertEqual(1999, parser.movies[0].year)
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
+        self.assertEqual("tt0137523", parser.movies[0].site_data[parser.site.site].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0137523", parser.movies[0]["imdb"]["url"]
+            "https://www.imdb.com/title/tt0137523", parser.movies[0].site_data[parser.site.site].url
         )
-        self.assertEqual(8, parser.movies[0]["icheckmovies"]["my_rating"])
+        self.assertEqual(8, parser.movies[0].site_data[parser.site.site].my_rating)
 
     @patch("RatS.base.base_ratings_parser.RatingsParser._print_progress_bar")
     @patch("RatS.utils.browser_handler.Firefox")
@@ -110,6 +113,7 @@ class ICheckMoviesParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.ICHECKMOVIES
         parser.site.site_name = "ICheckMovies"
         parser.site.browser = browser_mock
         parser.args = None
@@ -119,16 +123,18 @@ class ICheckMoviesParserTest(TestCase):
         )  # pylint: disable=protected-access
 
         self.assertEqual(25, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Daniel der Zauberer", parser.movies[0]["title"])
-        self.assertEqual("119234", parser.movies[0]["icheckmovies"]["id"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
+        self.assertEqual("Daniel der Zauberer", parser.movies[0].title)
+        self.assertEqual("119234", parser.movies[0].site_data[Site.ICHECKMOVIES].id)
         self.assertEqual(
             "https://www.icheckmovies.com/movies/daniel+der+zauberer/",
-            parser.movies[0]["icheckmovies"]["url"],
+            parser.movies[0].site_data[Site.ICHECKMOVIES].url,
         )
-        self.assertEqual(2004, parser.movies[0]["year"])
-        self.assertEqual("tt0421051", parser.movies[0]["imdb"]["id"])
+        self.assertEqual(2004, parser.movies[0].year)
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
+        self.assertEqual("tt0421051", parser.movies[0].site_data[Site.ICHECKMOVIES].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0421051", parser.movies[0]["imdb"]["url"]
+            "https://www.imdb.com/title/tt0421051", parser.movies[0].site_data[Site.ICHECKMOVIES].url
         )
-        self.assertEqual(3, parser.movies[0]["icheckmovies"]["my_rating"])
+        self.assertEqual(3, parser.movies[0].site_data[Site.ICHECKMOVIES].my_rating)

--- a/tests/unit/icheckmovies/test_icheckmovies_ratings_parser.py
+++ b/tests/unit/icheckmovies/test_icheckmovies_ratings_parser.py
@@ -85,7 +85,9 @@ class ICheckMoviesParserTest(TestCase):
 
         self.assertEqual(240, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES])
+        )
         self.assertEqual("Fight Club", parser.movies[0].title)
         self.assertEqual("21", parser.movies[0].site_data[Site.ICHECKMOVIES].id)
         self.assertEqual(
@@ -93,10 +95,13 @@ class ICheckMoviesParserTest(TestCase):
             parser.movies[0].site_data[Site.ICHECKMOVIES].url,
         )
         self.assertEqual(1999, parser.movies[0].year)
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
-        self.assertEqual("tt0137523", parser.movies[0].site_data[Site.ICHECKMOVIES].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0137523", parser.movies[0].site_data[Site.ICHECKMOVIES].url
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.IMDB])
+        )
+        self.assertEqual("tt0137523", parser.movies[0].site_data[Site.IMDB].id)
+        self.assertEqual(
+            "https://www.imdb.com/title/tt0137523",
+            parser.movies[0].site_data[Site.IMDB].url,
         )
         self.assertEqual(8, parser.movies[0].site_data[Site.ICHECKMOVIES].my_rating)
 
@@ -125,7 +130,9 @@ class ICheckMoviesParserTest(TestCase):
 
         self.assertEqual(25, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES])
+        )
         self.assertEqual("Daniel der Zauberer", parser.movies[0].title)
         self.assertEqual("119234", parser.movies[0].site_data[Site.ICHECKMOVIES].id)
         self.assertEqual(
@@ -133,9 +140,12 @@ class ICheckMoviesParserTest(TestCase):
             parser.movies[0].site_data[Site.ICHECKMOVIES].url,
         )
         self.assertEqual(2004, parser.movies[0].year)
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ICHECKMOVIES])
+        )
         self.assertEqual("tt0421051", parser.movies[0].site_data[Site.IMDB].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0421051", parser.movies[0].site_data[Site.IMDB].url
+            "https://www.imdb.com/title/tt0421051",
+            parser.movies[0].site_data[Site.IMDB].url,
         )
         self.assertEqual(3, parser.movies[0].site_data[Site.ICHECKMOVIES].my_rating)

--- a/tests/unit/imdb/test_imdb_ratings_inserter.py
+++ b/tests/unit/imdb/test_imdb_ratings_inserter.py
@@ -15,18 +15,18 @@ class IMDBRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["trakt"] = dict()
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie["trakt"] = SiteSpecificMovieData()
         self.movie["trakt"]["id"] = "432"
         self.movie["trakt"]["url"] = "https://trakt.tv/movies/fight-club-1999"
         self.movie["trakt"]["my_rating"] = "10"
         self.movie["trakt"]["overall_rating"] = "89%"
-        self.movie["tmdb"] = dict()
+        self.movie["tmdb"] = SiteSpecificMovieData()
         self.movie["tmdb"]["id"] = "550"
         self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
         with open(
@@ -94,7 +94,7 @@ class IMDBRatingsInserterTest(TestCase):
             class_="findResult"
         )[0]
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Arrival"
         movie2["year"] = 2006
 
@@ -120,7 +120,7 @@ class IMDBRatingsInserterTest(TestCase):
             class_="findResult"
         )[0]
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "SomeMovie"
         movie2["year"] = 1995
 
@@ -156,7 +156,7 @@ class IMDBRatingsInserterTest(TestCase):
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
 

--- a/tests/unit/imdb/test_imdb_ratings_inserter.py
+++ b/tests/unit/imdb/test_imdb_ratings_inserter.py
@@ -16,20 +16,20 @@ class IMDBRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.TRAKT] = SiteSpecificMovieData()
-        self.movie.site_data[Site.TRAKT].id = "432"
-        self.movie.site_data[Site.TRAKT].url = "https://trakt.tv/movies/fight-club-1999"
-        self.movie.site_data[Site.TRAKT].my_rating = "10"
-        # self.movie.site_data[Site.TRAKT]["overall_rating"] = "89%"  # TODO
-        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.TMDB].id = "550"
-        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+        )
+        self.movie.site_data[Site.TRAKT] = SiteSpecificMovieData(
+            id="432",
+            url="https://trakt.tv/movies/fight-club-1999",
+            my_rating="10",
+        )
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="550",
+            url="https://www.themoviedb.org/movie/550",
+        )
         with open(
             os.path.join(TESTDATA_PATH, "imdb", "search_result.html"), encoding="UTF-8"
         ) as search_result_tile:
@@ -98,9 +98,7 @@ class IMDBRatingsInserterTest(TestCase):
             class_="findResult"
         )[0]
 
-        movie2 = Movie()
-        movie2.title = "Arrival"
-        movie2.year = 2006
+        movie2 = Movie(title="Arrival", year=2006)
 
         result = inserter._is_requested_movie(
             movie2, search_result
@@ -125,9 +123,7 @@ class IMDBRatingsInserterTest(TestCase):
             class_="findResult"
         )[0]
 
-        movie2 = Movie()
-        movie2.title = "SomeMovie"
-        movie2.year = 1995
+        movie2 = Movie(title="SomeMovie", year=1995)
 
         result = inserter._is_requested_movie(
             movie2, search_result
@@ -163,9 +159,7 @@ class IMDBRatingsInserterTest(TestCase):
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
+        movie2 = Movie(title="The Matrix", year=1995)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/imdb/test_imdb_ratings_inserter.py
+++ b/tests/unit/imdb/test_imdb_ratings_inserter.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.imdb.imdb_ratings_inserter import IMDBRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -20,15 +21,15 @@ class IMDBRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["trakt"] = SiteSpecificMovieData()
-        self.movie["trakt"]["id"] = "432"
-        self.movie["trakt"]["url"] = "https://trakt.tv/movies/fight-club-1999"
-        self.movie["trakt"]["my_rating"] = "10"
-        self.movie["trakt"]["overall_rating"] = "89%"
-        self.movie["tmdb"] = SiteSpecificMovieData()
-        self.movie["tmdb"]["id"] = "550"
-        self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.TRAKT] = SiteSpecificMovieData()
+        self.movie.site_data[Site.TRAKT].id = "432"
+        self.movie.site_data[Site.TRAKT].url = "https://trakt.tv/movies/fight-club-1999"
+        self.movie.site_data[Site.TRAKT].my_rating = "10"
+        # self.movie.site_data[Site.TRAKT]["overall_rating"] = "89%"  # TODO
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.TMDB].id = "550"
+        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
         with open(
             os.path.join(TESTDATA_PATH, "imdb", "search_result.html"), encoding="UTF-8"
         ) as search_result_tile:
@@ -55,7 +56,7 @@ class IMDBRatingsInserterTest(TestCase):
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "Trakt")
+        inserter.insert([self.movie], Site.TRAKT)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -95,8 +96,8 @@ class IMDBRatingsInserterTest(TestCase):
         )[0]
 
         movie2 = Movie()
-        movie2["title"] = "Arrival"
-        movie2["year"] = 2006
+        movie2.title = "Arrival"
+        movie2.year = 2006
 
         result = inserter._is_requested_movie(
             movie2, search_result
@@ -121,8 +122,8 @@ class IMDBRatingsInserterTest(TestCase):
         )[0]
 
         movie2 = Movie()
-        movie2["title"] = "SomeMovie"
-        movie2["year"] = 1995
+        movie2.title = "SomeMovie"
+        movie2.year = 1995
 
         result = inserter._is_requested_movie(
             movie2, search_result
@@ -157,8 +158,8 @@ class IMDBRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
+        movie2.title = "The Matrix"
+        movie2.year = 1995
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/imdb/test_imdb_ratings_inserter.py
+++ b/tests/unit/imdb/test_imdb_ratings_inserter.py
@@ -53,6 +53,7 @@ class IMDBRatingsInserterTest(TestCase):
         inserter = IMDBRatingsInserter(None)
         inserter.args = False
         inserter.site = site_mock
+        inserter.site.site = Site.IMDB
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
 
@@ -68,6 +69,7 @@ class IMDBRatingsInserterTest(TestCase):
         site_mock.browser = browser_mock
         inserter = IMDBRatingsInserter(None)
         inserter.site = site_mock
+        inserter.site.site = Site.IMDB
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
         search_result_page = BeautifulSoup(self.search_result, "html.parser")
@@ -88,6 +90,7 @@ class IMDBRatingsInserterTest(TestCase):
         site_mock.browser = browser_mock
         inserter = IMDBRatingsInserter(None)
         inserter.site = site_mock
+        inserter.site.site = Site.IMDB
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
         search_result_page = BeautifulSoup(self.search_result, "html.parser")
@@ -114,6 +117,7 @@ class IMDBRatingsInserterTest(TestCase):
         site_mock.browser = browser_mock
         inserter = IMDBRatingsInserter(None)
         inserter.site = site_mock
+        inserter.site.site = Site.IMDB
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
         search_result_page = BeautifulSoup(self.search_result, "html.parser")
@@ -139,6 +143,7 @@ class IMDBRatingsInserterTest(TestCase):
         browser_mock.page_source = self.search_result
         inserter = IMDBRatingsInserter(None)
         inserter.site = site_mock
+        inserter.site.site = Site.IMDB
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
 
@@ -154,6 +159,7 @@ class IMDBRatingsInserterTest(TestCase):
         browser_mock.page_source = self.search_result
         inserter = IMDBRatingsInserter(None)
         inserter.site = site_mock
+        inserter.site.site = Site.IMDB
         inserter.site.site_name = "IMDB"
         inserter.failed_movies = []
 

--- a/tests/unit/imdb/test_imdb_ratings_parser.py
+++ b/tests/unit/imdb/test_imdb_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Site
 from RatS.imdb.imdb_ratings_parser import IMDBRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -41,6 +42,7 @@ class IMDBParserTest(TestCase):
         parser.movies = []
         parser.site = site_mock
         parser.site.site_name = "IMDB"
+        parser.site.site = Site.IMDB
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))
         parser.csv_filename = "1234567890_imdb.csv"
@@ -61,6 +63,7 @@ class IMDBParserTest(TestCase):
         parser = IMDBRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.IMDB
         parser.site.site_name = "IMDB"
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))

--- a/tests/unit/letterboxd/test_letterboxd_ratings_inserter.py
+++ b/tests/unit/letterboxd/test_letterboxd_ratings_inserter.py
@@ -13,12 +13,12 @@ class LetterboxdRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
 
     @patch("RatS.letterboxd.letterboxd_site.Letterboxd._user_is_not_logged_in")
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")

--- a/tests/unit/letterboxd/test_letterboxd_ratings_inserter.py
+++ b/tests/unit/letterboxd/test_letterboxd_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.letterboxd.letterboxd_ratings_inserter import LetterboxdRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -17,8 +18,8 @@ class LetterboxdRatingsInserterTest(TestCase):
         self.movie.title = "Fight Club"
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
 
     @patch("RatS.letterboxd.letterboxd_site.Letterboxd._user_is_not_logged_in")
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")
@@ -55,7 +56,7 @@ class LetterboxdRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         inserter.exports_folder = TESTDATA_PATH
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(impex_mock.called)

--- a/tests/unit/letterboxd/test_letterboxd_ratings_inserter.py
+++ b/tests/unit/letterboxd/test_letterboxd_ratings_inserter.py
@@ -14,12 +14,10 @@ class LetterboxdRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Fight Club")
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523", url="https://www.imdb.com/title/tt0137523", my_rating=9
+        )
 
     @patch("RatS.letterboxd.letterboxd_site.Letterboxd._user_is_not_logged_in")
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")

--- a/tests/unit/letterboxd/test_letterboxd_ratings_parser.py
+++ b/tests/unit/letterboxd/test_letterboxd_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Site, Movie
 from RatS.letterboxd.letterboxd_ratings_parser import LetterboxdRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -47,6 +48,7 @@ class LetterboxdParserTest(TestCase):
         parser = LetterboxdRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.LETTERBOXD
         parser.site.site_name = "Letterboxd"
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))
@@ -71,6 +73,7 @@ class LetterboxdParserTest(TestCase):
         parser = LetterboxdRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.LETTERBOXD
         parser.site.site_name = "Letterboxd"
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))
@@ -107,6 +110,7 @@ class LetterboxdParserTest(TestCase):
         parser = LetterboxdRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.LETTERBOXD
         parser.site.site_name = "Letterboxd"
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))
@@ -120,10 +124,10 @@ class LetterboxdParserTest(TestCase):
         )  # pylint: disable=protected-access
 
         self.assertEqual(1056, len(movies))
-        self.assertEqual(dict, type(movies[0]))
-        self.assertEqual("Life", movies[0]["title"])
-        self.assertEqual(2017, movies[0]["year"])
+        self.assertEqual(Movie, type(movies[0]))
+        self.assertEqual("Life", movies[0].title)
+        self.assertEqual(2017, movies[0].year)
         self.assertEqual(
-            "https://letterboxd.com/film/life-2017/", movies[0]["letterboxd"]["url"]
+            "https://letterboxd.com/film/life-2017/", movies[0][Site.LETTERBOXD].url
         )
-        self.assertEqual(7, movies[0]["letterboxd"]["my_rating"])
+        self.assertEqual(7, movies[0][Site.LETTERBOXD].my_rating)

--- a/tests/unit/letterboxd/test_letterboxd_ratings_parser.py
+++ b/tests/unit/letterboxd/test_letterboxd_ratings_parser.py
@@ -129,6 +129,7 @@ class LetterboxdParserTest(TestCase):
         self.assertEqual("Life", movies[0].title)
         self.assertEqual(2017, movies[0].year)
         self.assertEqual(
-            "https://letterboxd.com/film/life-2017/", movies[0].site_data[Site.LETTERBOXD].url
+            "https://letterboxd.com/film/life-2017/",
+            movies[0].site_data[Site.LETTERBOXD].url,
         )
         self.assertEqual(7, movies[0].site_data[Site.LETTERBOXD].my_rating)

--- a/tests/unit/letterboxd/test_letterboxd_ratings_parser.py
+++ b/tests/unit/letterboxd/test_letterboxd_ratings_parser.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -119,7 +120,7 @@ class LetterboxdParserTest(TestCase):
             os.pardir, "letterboxd", "my_ratings.csv"
         )
 
-        movies = parser._parse_movies_from_csv(
+        movies: List[Movie] = parser._parse_movies_from_csv(
             os.path.join(TESTDATA_PATH, "letterboxd", "my_ratings.csv")
         )  # pylint: disable=protected-access
 
@@ -128,6 +129,6 @@ class LetterboxdParserTest(TestCase):
         self.assertEqual("Life", movies[0].title)
         self.assertEqual(2017, movies[0].year)
         self.assertEqual(
-            "https://letterboxd.com/film/life-2017/", movies[0][Site.LETTERBOXD].url
+            "https://letterboxd.com/film/life-2017/", movies[0].site_data[Site.LETTERBOXD].url
         )
-        self.assertEqual(7, movies[0][Site.LETTERBOXD].my_rating)
+        self.assertEqual(7, movies[0].site_data[Site.LETTERBOXD].my_rating)

--- a/tests/unit/listal/test_listal_ratings_inserter.py
+++ b/tests/unit/listal/test_listal_ratings_inserter.py
@@ -16,16 +16,14 @@ class ListalRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
-        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.TMDB].id = "550"
-        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523", url="https://www.imdb.com/title/tt0137523", my_rating=9
+        )
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="550",
+            url="https://www.themoviedb.org/movie/550",
+        )
         with open(
             os.path.join(TESTDATA_PATH, "listal", "search_result.html"),
             encoding="UTF-8",
@@ -116,13 +114,12 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "The Simpsons"
-        movie2.year = 2007
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0462538"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0462538"
-        movie2.site_data[Site.IMDB].my_rating = 10
+        movie2 = Movie(title="The Simpsons", year=2007)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0462538",
+            url="https://www.imdb.com/title/tt0462538",
+            my_rating=10,
+        )
 
         result = inserter._compare_external_links(
             self.movie_details_page, movie2, "imdb.com", Site.IMDB
@@ -172,9 +169,7 @@ class ListalRatingsInserterTest(TestCase):
         compare_mock.return_value = True
         equality_mock.return_value = True
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -211,13 +206,12 @@ class ListalRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="The Matrix", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -236,9 +230,7 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -260,13 +252,12 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1998
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="Fight Club", year=1998)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -288,9 +279,7 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
+        movie2 = Movie(title="The Matrix", year=1995)
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -323,9 +312,7 @@ class ListalRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         inserter.args = None
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(

--- a/tests/unit/listal/test_listal_ratings_inserter.py
+++ b/tests/unit/listal/test_listal_ratings_inserter.py
@@ -15,14 +15,14 @@ class ListalRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
-        self.movie["tmdb"] = dict()
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie["tmdb"] = SiteSpecificMovieData()
         self.movie["tmdb"]["id"] = "550"
         self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
         with open(
@@ -115,10 +115,10 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Simpsons"
         movie2["year"] = 2007
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0462538"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0462538"
         movie2["imdb"]["my_rating"] = 10
@@ -171,7 +171,7 @@ class ListalRatingsInserterTest(TestCase):
         compare_mock.return_value = True
         equality_mock.return_value = True
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -210,10 +210,10 @@ class ListalRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9
@@ -235,7 +235,7 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -259,10 +259,10 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1998
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9
@@ -287,7 +287,7 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
 
@@ -322,7 +322,7 @@ class ListalRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         inserter.args = None
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 

--- a/tests/unit/listal/test_listal_ratings_inserter.py
+++ b/tests/unit/listal/test_listal_ratings_inserter.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.listal.listal_ratings_inserter import ListalRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -20,11 +21,11 @@ class ListalRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
-        self.movie["tmdb"] = SiteSpecificMovieData()
-        self.movie["tmdb"]["id"] = "550"
-        self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.TMDB].id = "550"
+        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
         with open(
             os.path.join(TESTDATA_PATH, "listal", "search_result.html"),
             encoding="UTF-8",
@@ -80,7 +81,7 @@ class ListalRatingsInserterTest(TestCase):
         inserter.site.site_name = "Listal"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -98,7 +99,7 @@ class ListalRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         result = inserter._compare_external_links(
-            self.movie_details_page, self.movie, "imdb.com", "imdb"
+            self.movie_details_page, self.movie, "imdb.com", Site.IMDB
         )  # pylint: disable=protected-access
 
         self.assertTrue(result)
@@ -116,15 +117,15 @@ class ListalRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "The Simpsons"
-        movie2["year"] = 2007
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0462538"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0462538"
-        movie2["imdb"]["my_rating"] = 10
+        movie2.title = "The Simpsons"
+        movie2.year = 2007
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0462538"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0462538"
+        movie2.site_data[Site.IMDB].my_rating = 10
 
         result = inserter._compare_external_links(
-            self.movie_details_page, movie2, "imdb.com", "imdb"
+            self.movie_details_page, movie2, "imdb.com", Site.IMDB
         )  # pylint: disable=protected-access
 
         self.assertFalse(result)
@@ -172,8 +173,8 @@ class ListalRatingsInserterTest(TestCase):
         equality_mock.return_value = True
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -211,12 +212,12 @@ class ListalRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -236,8 +237,8 @@ class ListalRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -260,12 +261,12 @@ class ListalRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1998
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "Fight Club"
+        movie2.year = 1998
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -288,8 +289,8 @@ class ListalRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
+        movie2.title = "The Matrix"
+        movie2.year = 1995
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(
@@ -323,8 +324,8 @@ class ListalRatingsInserterTest(TestCase):
         inserter.args = None
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(

--- a/tests/unit/listal/test_listal_ratings_parser.py
+++ b/tests/unit/listal/test_listal_ratings_parser.py
@@ -76,11 +76,13 @@ class ListalParserTest(TestCase):
         parser.site.site_name = "Listal"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
-        movie = dict()
+        movie = Movie()
 
         parser.parse_movie_details_page(movie)
 
-        self.assertEqual(1999, movie["year"])
+        self.assertEqual(1999, movie.year)
         self.assertEqual(10, movie["listal"]["my_rating"])
-        self.assertEqual("tt0137523", movie["imdb"]["id"])
-        self.assertEqual("https://www.imdb.com/title/tt0137523", movie["imdb"]["url"])
+        self.assertEqual("tt0137523", movie.site_data[Site.IMDB].id)
+        self.assertEqual(
+            "https://www.imdb.com/title/tt0137523", movie.site_data[Site.IMDB]["url"]
+        )

--- a/tests/unit/listal/test_listal_ratings_parser.py
+++ b/tests/unit/listal/test_listal_ratings_parser.py
@@ -61,11 +61,14 @@ class ListalParserTest(TestCase):
         self.assertEqual(60, parse_movie_mock.call_count)
         self.assertEqual(60, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site])
+        )
         self.assertEqual("Fight Club", parser.movies[0].title)
         self.assertEqual("1596", parser.movies[0].site_data[Site.LISTAL].id)
         self.assertEqual(
-            "https://www.listal.com/movie/fight-club", parser.movies[0].site_data[Site.LISTAL].url
+            "https://www.listal.com/movie/fight-club",
+            parser.movies[0].site_data[Site.LISTAL].url,
         )
 
     @patch("RatS.utils.browser_handler.Firefox")
@@ -80,7 +83,7 @@ class ListalParserTest(TestCase):
         parser.site.site_name = "Listal"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
-        movie = Movie()
+        movie = Movie(title="doesn't matter right now")
 
         parser.parse_movie_details_page(movie)
 

--- a/tests/unit/listal/test_listal_ratings_parser.py
+++ b/tests/unit/listal/test_listal_ratings_parser.py
@@ -63,9 +63,9 @@ class ListalParserTest(TestCase):
         self.assertEqual(Movie, type(parser.movies[0]))
         self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
         self.assertEqual("Fight Club", parser.movies[0].title)
-        self.assertEqual("1596", parser.movies[0].site_date[Site.LISTAL].id)
+        self.assertEqual("1596", parser.movies[0].site_data[Site.LISTAL].id)
         self.assertEqual(
-            "https://www.listal.com/movie/fight-club", parser.movies[0].site_date[Site.LISTAL].url
+            "https://www.listal.com/movie/fight-club", parser.movies[0].site_data[Site.LISTAL].url
         )
 
     @patch("RatS.utils.browser_handler.Firefox")

--- a/tests/unit/listal/test_listal_ratings_parser.py
+++ b/tests/unit/listal/test_listal_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.listal.listal_ratings_parser import ListalRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -50,6 +51,7 @@ class ListalParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.LISTAL
         parser.site.site_name = "Listal"
         parser.site.browser = browser_mock
         parser.args = None
@@ -58,11 +60,12 @@ class ListalParserTest(TestCase):
 
         self.assertEqual(60, parse_movie_mock.call_count)
         self.assertEqual(60, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Fight Club", parser.movies[0]["title"])
-        self.assertEqual("1596", parser.movies[0]["listal"]["id"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[parser.site.site]))
+        self.assertEqual("Fight Club", parser.movies[0].title)
+        self.assertEqual("1596", parser.movies[0].site_date[Site.LISTAL].id)
         self.assertEqual(
-            "https://www.listal.com/movie/fight-club", parser.movies[0]["listal"]["url"]
+            "https://www.listal.com/movie/fight-club", parser.movies[0].site_date[Site.LISTAL].url
         )
 
     @patch("RatS.utils.browser_handler.Firefox")
@@ -73,6 +76,7 @@ class ListalParserTest(TestCase):
         parser = ListalRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.LISTAL
         parser.site.site_name = "Listal"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
@@ -81,8 +85,8 @@ class ListalParserTest(TestCase):
         parser.parse_movie_details_page(movie)
 
         self.assertEqual(1999, movie.year)
-        self.assertEqual(10, movie["listal"]["my_rating"])
+        self.assertEqual(10, movie.site_data[Site.LISTAL].my_rating)
         self.assertEqual("tt0137523", movie.site_data[Site.IMDB].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0137523", movie.site_data[Site.IMDB]["url"]
+            "https://www.imdb.com/title/tt0137523", movie.site_data[Site.IMDB].url
         )

--- a/tests/unit/metacritic/test_metacritic_ratings_inserter.py
+++ b/tests/unit/metacritic/test_metacritic_ratings_inserter.py
@@ -16,13 +16,12 @@ class MetacriticRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
         with open(
             os.path.join(TESTDATA_PATH, "metacritic", "search_result.html"),
             encoding="UTF-8",
@@ -125,9 +124,7 @@ class MetacriticRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
+        movie2 = Movie(title="The Matrix", year=1995)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -168,9 +165,7 @@ class MetacriticRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         inserter.args = None
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
+        movie2 = Movie(title="The Matrix", year=1995)
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(

--- a/tests/unit/metacritic/test_metacritic_ratings_inserter.py
+++ b/tests/unit/metacritic/test_metacritic_ratings_inserter.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
+from RatS.base.movie_entity import Site, SiteSpecificMovieData, Movie
 from RatS.metacritic.metacritic_ratings_inserter import MetacriticRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -20,8 +21,8 @@ class MetacriticRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
         with open(
             os.path.join(TESTDATA_PATH, "metacritic", "search_result.html"),
             encoding="UTF-8",
@@ -73,7 +74,7 @@ class MetacriticRatingsInserterTest(TestCase):
         inserter.site.site_name = "Metacritic"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -125,8 +126,8 @@ class MetacriticRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
+        movie2.title = "The Matrix"
+        movie2.year = 1995
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -168,8 +169,8 @@ class MetacriticRatingsInserterTest(TestCase):
         inserter.args = None
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
+        movie2.title = "The Matrix"
+        movie2.year = 1995
 
         search_result = BeautifulSoup(self.search_result_tile_list[0], "html.parser")
         result = inserter._is_requested_movie(

--- a/tests/unit/metacritic/test_metacritic_ratings_inserter.py
+++ b/tests/unit/metacritic/test_metacritic_ratings_inserter.py
@@ -15,13 +15,13 @@ class MetacriticRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
         with open(
             os.path.join(TESTDATA_PATH, "metacritic", "search_result.html"),
             encoding="UTF-8",
@@ -124,7 +124,7 @@ class MetacriticRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
 
@@ -167,7 +167,7 @@ class MetacriticRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         inserter.args = None
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
 

--- a/tests/unit/movielens/test_movielens_ratings_inserter.py
+++ b/tests/unit/movielens/test_movielens_ratings_inserter.py
@@ -13,12 +13,12 @@ class MovielensUploaderTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
 
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")
     @patch("RatS.utils.browser_handler.Firefox")

--- a/tests/unit/movielens/test_movielens_ratings_inserter.py
+++ b/tests/unit/movielens/test_movielens_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, SiteSpecificMovieData, Site
 from RatS.movielens.movielens_ratings_inserter import MovielensRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -17,8 +18,8 @@ class MovielensUploaderTest(TestCase):
         self.movie.title = "Fight Club"
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
 
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")
     @patch("RatS.utils.browser_handler.Firefox")
@@ -42,7 +43,7 @@ class MovielensUploaderTest(TestCase):
         inserter.exports_folder = TESTDATA_PATH
         inserter.csv_filename = "converted.csv"
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(impex_mock.called)

--- a/tests/unit/movielens/test_movielens_ratings_inserter.py
+++ b/tests/unit/movielens/test_movielens_ratings_inserter.py
@@ -14,12 +14,12 @@ class MovielensUploaderTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Fight Club")
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
     @patch("RatS.base.base_ratings_inserter.RatingsInserter.__init__")
     @patch("RatS.utils.browser_handler.Firefox")

--- a/tests/unit/movielens/test_movielens_ratings_parser.py
+++ b/tests/unit/movielens/test_movielens_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Site, Movie
 from RatS.movielens.movielens_ratings_parser import MovielensRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -36,6 +37,7 @@ class MovielensParserTest(TestCase):
         parser = MovielensRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.MOVIELENS
         parser.site.site_name = "Movielens"
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))
@@ -58,6 +60,7 @@ class MovielensParserTest(TestCase):
         parser = MovielensRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.MOVIELENS
         parser.site.site_name = "Movielens"
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))
@@ -104,6 +107,7 @@ class MovielensParserTest(TestCase):
         parser = MovielensRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.MOVIELENS
         parser.site.site_name = "Movielens"
         parser.site.browser = browser_mock
         parser.exports_folder = os.path.abspath(os.path.join(TESTDATA_PATH, "exports"))
@@ -118,19 +122,19 @@ class MovielensParserTest(TestCase):
         )  # pylint: disable=protected-access
 
         self.assertEqual(1063, len(movies))
-        self.assertEqual(dict, type(movies[0]))
+        self.assertEqual(Movie, type(movies[0]))
 
-        self.assertEqual("Toy Story", movies[0]["title"])
-        self.assertEqual(1995, movies[0]["year"])
-        self.assertEqual("1", movies[0]["movielens"]["id"])
+        self.assertEqual("Toy Story", movies[0].title)
+        self.assertEqual(1995, movies[0].year)
+        self.assertEqual("1", movies[0].site_data[Site.MOVIELENS].id)
         self.assertEqual(
-            "https://movielens.org/movies/1", movies[0]["movielens"]["url"]
+            "https://movielens.org/movies/1", movies[0].site_data[Site.MOVIELENS].url
         )
-        self.assertEqual(8, movies[0]["movielens"]["my_rating"])
+        self.assertEqual(8, movies[0].site_data[Site.MOVIELENS].my_rating)
 
-        self.assertEqual("tt0114709", movies[0]["imdb"]["id"])
+        self.assertEqual("tt0114709", movies[0].site_data[Site.IMDB].id)
         self.assertEqual(
-            "https://www.imdb.com/title/tt0114709", movies[0]["imdb"]["url"]
+            "https://www.imdb.com/title/tt0114709", movies[0].site_data[Site.IMDB].url
         )
         self.assertEqual("862", movies[0]["tmdb"]["id"])
         self.assertEqual(

--- a/tests/unit/movielens/test_movielens_ratings_parser.py
+++ b/tests/unit/movielens/test_movielens_ratings_parser.py
@@ -136,7 +136,7 @@ class MovielensParserTest(TestCase):
         self.assertEqual(
             "https://www.imdb.com/title/tt0114709", movies[0].site_data[Site.IMDB].url
         )
-        self.assertEqual("862", movies[0]["tmdb"]["id"])
+        self.assertEqual("862", movies[0].site_data[Site.TMDB].id)
         self.assertEqual(
-            "https://www.themoviedb.org/movie/862", movies[0]["tmdb"]["url"]
+            "https://www.themoviedb.org/movie/862", movies[0].site_data[Site.TMDB].url
         )

--- a/tests/unit/movielens/test_movielens_site.py
+++ b/tests/unit/movielens/test_movielens_site.py
@@ -22,7 +22,7 @@ class MovielensSiteTest(TestCase):
             self.my_ratings_json = json.loads(self.my_ratings_pre)
 
     @patch("RatS.utils.browser_handler.Firefox")
-    @patch("RatS.base.base_site.Site._init_browser")
+    @patch("RatS.base.base_site.BaseSite._init_browser")
     def test_get_json_from_html(self, init_browser_mock, browser_mock):
         site = Movielens(None)
         site.browser = browser_mock

--- a/tests/unit/moviepilot/test_moviepilot_ratings_inserter.py
+++ b/tests/unit/moviepilot/test_moviepilot_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.moviepilot.moviepilot_ratings_inserter import MoviePilotRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -18,8 +19,8 @@ class MoviePilotRatingsInserterTest(TestCase):
         self.movie.year = 1979
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0079945"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0079945"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0079945"
+        self.movie.site_data[Site.IMDB].my_rating = 9
         with open(
             os.path.join(TESTDATA_PATH, "moviepilot", "search_result.html"),
             encoding="UTF-8",
@@ -75,7 +76,7 @@ class MoviePilotRatingsInserterTest(TestCase):
         inserter.site.site_name = "MoviePilot"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -99,8 +100,8 @@ class MoviePilotRatingsInserterTest(TestCase):
         movie_details_mock.return_value = True
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -128,12 +129,12 @@ class MoviePilotRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/moviepilot/test_moviepilot_ratings_inserter.py
+++ b/tests/unit/moviepilot/test_moviepilot_ratings_inserter.py
@@ -13,13 +13,13 @@ class MoviePilotRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Star Trek"
-        self.movie["year"] = 1979
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0079945"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0079945"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Star Trek"
+        self.movie.year = 1979
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0079945"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0079945"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
         with open(
             os.path.join(TESTDATA_PATH, "moviepilot", "search_result.html"),
             encoding="UTF-8",
@@ -98,7 +98,7 @@ class MoviePilotRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         movie_details_mock.return_value = True
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -127,10 +127,10 @@ class MoviePilotRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9

--- a/tests/unit/moviepilot/test_moviepilot_ratings_inserter.py
+++ b/tests/unit/moviepilot/test_moviepilot_ratings_inserter.py
@@ -14,13 +14,12 @@ class MoviePilotRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Star Trek"
-        self.movie.year = 1979
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0079945"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0079945"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Star Trek", year=1979)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0079945",
+            url="https://www.imdb.com/title/tt0079945",
+            my_rating=9,
+        )
         with open(
             os.path.join(TESTDATA_PATH, "moviepilot", "search_result.html"),
             encoding="UTF-8",
@@ -99,9 +98,7 @@ class MoviePilotRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         movie_details_mock.return_value = True
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -128,13 +125,12 @@ class MoviePilotRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="The Matrix", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/moviepilot/test_moviepilot_ratings_parser.py
+++ b/tests/unit/moviepilot/test_moviepilot_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.moviepilot.moviepilot_ratings_parser import MoviePilotRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -55,6 +56,7 @@ class MoviePilotRatingsParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.MOVIEPILOT
         parser.site.site_name = "MoviePilot"
         parser.site.browser = browser_mock
         parser.args = None
@@ -65,11 +67,12 @@ class MoviePilotRatingsParserTest(TestCase):
 
         self.assertEqual(1, parse_movie_mock.call_count)
         self.assertEqual(1, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Star Trek - Der Film", parser.movies[0]["title"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.MOVIEPILOT]))
+        self.assertEqual("Star Trek - Der Film", parser.movies[0].title)
         self.assertEqual(
             "https://www.moviepilot.de/movies/star-trek-der-film",
-            parser.movies[0]["moviepilot"]["url"],
+            parser.movies[0].site_data[Site.MOVIEPILOT].url,
         )
 
     @patch(
@@ -85,6 +88,7 @@ class MoviePilotRatingsParserTest(TestCase):
         parser = MoviePilotRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.MOVIEPILOT
         parser.site.site_name = "MoviePilot"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
@@ -95,5 +99,5 @@ class MoviePilotRatingsParserTest(TestCase):
 
         # Star Trek
         self.assertEqual(1979, movie.year)
-        self.assertEqual("1442", movie["moviepilot"]["id"])
-        self.assertEqual(10, movie["moviepilot"]["my_rating"])
+        self.assertEqual("1442", movie.site_data[Site.MOVIEPILOT].id)
+        self.assertEqual(10, movie.site_data[Site.MOVIEPILOT].my_rating)

--- a/tests/unit/moviepilot/test_moviepilot_ratings_parser.py
+++ b/tests/unit/moviepilot/test_moviepilot_ratings_parser.py
@@ -68,7 +68,9 @@ class MoviePilotRatingsParserTest(TestCase):
         self.assertEqual(1, parse_movie_mock.call_count)
         self.assertEqual(1, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.MOVIEPILOT]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.MOVIEPILOT])
+        )
         self.assertEqual("Star Trek - Der Film", parser.movies[0].title)
         self.assertEqual(
             "https://www.moviepilot.de/movies/star-trek-der-film",
@@ -92,7 +94,7 @@ class MoviePilotRatingsParserTest(TestCase):
         parser.site.site_name = "MoviePilot"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
-        movie = Movie()
+        movie = Movie(title="doesn't matter right now")
         rating_mock.return_value = 10
 
         parser.parse_movie_details_page(movie)

--- a/tests/unit/moviepilot/test_moviepilot_ratings_parser.py
+++ b/tests/unit/moviepilot/test_moviepilot_ratings_parser.py
@@ -88,12 +88,12 @@ class MoviePilotRatingsParserTest(TestCase):
         parser.site.site_name = "MoviePilot"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
-        movie = dict()
+        movie = Movie()
         rating_mock.return_value = 10
 
         parser.parse_movie_details_page(movie)
 
         # Star Trek
-        self.assertEqual(1979, movie["year"])
+        self.assertEqual(1979, movie.year)
         self.assertEqual("1442", movie["moviepilot"]["id"])
         self.assertEqual(10, movie["moviepilot"]["my_rating"])

--- a/tests/unit/plex/test_plex_ratings_inserter.py
+++ b/tests/unit/plex/test_plex_ratings_inserter.py
@@ -13,14 +13,14 @@ class PlexRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "http://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
-        self.movie["tmdb"] = dict()
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "http://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie["tmdb"] = SiteSpecificMovieData()
         self.movie["tmdb"]["id"] = "550"
         self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
         with open(
@@ -109,10 +109,10 @@ class PlexRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "http://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9

--- a/tests/unit/plex/test_plex_ratings_inserter.py
+++ b/tests/unit/plex/test_plex_ratings_inserter.py
@@ -14,16 +14,16 @@ class PlexRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "http://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
-        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.TMDB].id = "550"
-        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="http://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="550",
+            url="https://www.themoviedb.org/movie/550",
+        )
         with open(
             os.path.join(TESTDATA_PATH, "plex", "search_result.xml"), encoding="UTF-8"
         ) as search_results:
@@ -110,13 +110,12 @@ class PlexRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "http://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="The Matrix", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="http://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/plex/test_plex_ratings_inserter.py
+++ b/tests/unit/plex/test_plex_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.plex.plex_ratings_inserter import PlexRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -18,11 +19,11 @@ class PlexRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "http://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
-        self.movie["tmdb"] = SiteSpecificMovieData()
-        self.movie["tmdb"]["id"] = "550"
-        self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
+        self.movie.site_data[Site.IMDB].url = "http://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.TMDB].id = "550"
+        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
         with open(
             os.path.join(TESTDATA_PATH, "plex", "search_result.xml"), encoding="UTF-8"
         ) as search_results:
@@ -67,7 +68,7 @@ class PlexRatingsInserterTest(TestCase):
         inserter.site.site_name = "Plex"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -110,12 +111,12 @@ class PlexRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "http://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "http://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/plex/test_plex_ratings_parser.py
+++ b/tests/unit/plex/test_plex_ratings_parser.py
@@ -81,8 +81,8 @@ class PlexRatingsParserTest(TestCase):
         )  # pylint: disable=protected-access
 
         self.assertEqual(dict, type(movie))
-        self.assertEqual("Fight Club", movie["title"])
-        self.assertEqual(1999, movie["year"])
+        self.assertEqual("Fight Club", movie.title)
+        self.assertEqual(1999, movie.year)
         self.assertEqual(10, movie["plex"]["my_rating"])
         self.assertEqual("19542", movie["plex"]["id"])
         self.assertEqual(

--- a/tests/unit/plex/test_plex_ratings_parser.py
+++ b/tests/unit/plex/test_plex_ratings_parser.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
+from RatS.base.movie_entity import Movie, Site
 from RatS.plex.plex_ratings_parser import PlexRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -54,6 +55,7 @@ class PlexRatingsParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.PLEX
         parser.site.site_name = "Plex"
         parser.site.browser = browser_mock
         parser.args = None
@@ -71,6 +73,7 @@ class PlexRatingsParserTest(TestCase):
         parser = PlexRatingsParser(None)
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.PLEX
         parser.site.site_name = "Plex"
         parser.site.BASE_URL = "localhost:12345"
         parser.site.SERVER_ID = "ThisIsAMockUUID"
@@ -80,14 +83,14 @@ class PlexRatingsParserTest(TestCase):
             self.ratings_tile
         )  # pylint: disable=protected-access
 
-        self.assertEqual(dict, type(movie))
+        self.assertEqual(Movie, type(movie))
         self.assertEqual("Fight Club", movie.title)
         self.assertEqual(1999, movie.year)
-        self.assertEqual(10, movie["plex"]["my_rating"])
-        self.assertEqual("19542", movie["plex"]["id"])
+        self.assertEqual(10, movie.site_data[Site.PLEX].my_rating)
+        self.assertEqual("19542", movie.site_data[Site.PLEX].id)
         self.assertEqual(
             "http://localhost:12345/web/index.html#!"
             "/server/ThisIsAMockUUID/"
             "details?key=%2Flibrary%2Fmetadata%2F19542",
-            movie["plex"]["url"],
+            movie.site_data[Site.PLEX].url,
         )

--- a/tests/unit/plex/test_plex_site.py
+++ b/tests/unit/plex/test_plex_site.py
@@ -2,6 +2,8 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.base_site import BaseSite
+from RatS.base.movie_entity import Site
 from RatS.plex.plex_site import Plex
 
 TESTDATA_PATH = os.path.abspath(
@@ -31,7 +33,7 @@ class PlexSiteTest(TestCase):
 
         self.assertEqual("ThisIsAMockUUID", result)
 
-    @patch("RatS.base.base_site.Site._insert_login_credentials")
+    @patch("RatS.base.base_site.BaseSite._insert_login_credentials")
     @patch("RatS.plex.plex_site.Plex._parse_configuration")
     @patch("RatS.utils.browser_handler.Firefox")
     @patch("RatS.base.base_site.BaseSite._init_browser")
@@ -41,7 +43,8 @@ class PlexSiteTest(TestCase):
         browser_mock.current_url = (
             "http://localhost/web/index.html#!/settings/server/ThisIsAMockUUID/general"
         )
-        site = Plex(None)
+        site: BaseSite = Plex(None)
+        site.site = Site.PLEX
         site.browser = browser_mock
         site.BASE_URL = "localhost"
 

--- a/tests/unit/plex/test_plex_site.py
+++ b/tests/unit/plex/test_plex_site.py
@@ -16,7 +16,7 @@ class PlexSiteTest(TestCase):
 
     @patch("RatS.plex.plex_site.Plex._parse_configuration")
     @patch("RatS.utils.browser_handler.Firefox")
-    @patch("RatS.base.base_site.Site._init_browser")
+    @patch("RatS.base.base_site.BaseSite._init_browser")
     def test_determine_server_id(
         self, init_browser_mock, browser_mock, configuration_mock
     ):
@@ -34,7 +34,7 @@ class PlexSiteTest(TestCase):
     @patch("RatS.base.base_site.Site._insert_login_credentials")
     @patch("RatS.plex.plex_site.Plex._parse_configuration")
     @patch("RatS.utils.browser_handler.Firefox")
-    @patch("RatS.base.base_site.Site._init_browser")
+    @patch("RatS.base.base_site.BaseSite._init_browser")
     def test_insert_login_credentials(
         self, init_browser_mock, browser_mock, configuration_mock, base_site_mock
     ):
@@ -52,7 +52,7 @@ class PlexSiteTest(TestCase):
     @patch("RatS.plex.plex_site.Plex._determine_plex_token")
     @patch("RatS.plex.plex_site.Plex._determine_server_id")
     @patch("RatS.utils.browser_handler.Firefox")
-    @patch("RatS.base.base_site.Site._init_browser")
+    @patch("RatS.base.base_site.BaseSite._init_browser")
     def test_parse_configuration(
         self, init_browser_mock, browser_mock, server_id_mock, plex_token_mock
     ):
@@ -79,7 +79,7 @@ class PlexSiteTest(TestCase):
     @patch("re.findall")
     @patch("RatS.plex.plex_site.Plex._parse_configuration")
     @patch("RatS.utils.browser_handler.Firefox")
-    @patch("RatS.base.base_site.Site._init_browser")
+    @patch("RatS.base.base_site.BaseSite._init_browser")
     def test_determine_plex_token(
         self, init_browser_mock, browser_mock, configuration_mock, regex_mock
     ):

--- a/tests/unit/rottentomatoes/test_rottentomatoes_ratings_inserter.py
+++ b/tests/unit/rottentomatoes/test_rottentomatoes_ratings_inserter.py
@@ -16,14 +16,14 @@ class RottenTomatoesRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
-        self.movie["tmdb"] = dict()
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie["tmdb"] = SiteSpecificMovieData()
         self.movie["tmdb"]["id"] = "550"
         self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
         with open(
@@ -123,10 +123,10 @@ class RottenTomatoesRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9

--- a/tests/unit/rottentomatoes/test_rottentomatoes_ratings_inserter.py
+++ b/tests/unit/rottentomatoes/test_rottentomatoes_ratings_inserter.py
@@ -3,6 +3,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.rottentomatoes.rottentomatoes_ratings_inserter import (
     RottenTomatoesRatingsInserter,
 )
@@ -21,11 +22,11 @@ class RottenTomatoesRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
-        self.movie["tmdb"] = SiteSpecificMovieData()
-        self.movie["tmdb"]["id"] = "550"
-        self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.TMDB].id = "550"
+        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
         with open(
             os.path.join(TESTDATA_PATH, "rottentomatoes", "search_result.json"),
             encoding="UTF-8",
@@ -76,7 +77,7 @@ class RottenTomatoesRatingsInserterTest(TestCase):
         inserter.site.site_name = "RottenTomatoes"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -124,12 +125,12 @@ class RottenTomatoesRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/rottentomatoes/test_rottentomatoes_ratings_inserter.py
+++ b/tests/unit/rottentomatoes/test_rottentomatoes_ratings_inserter.py
@@ -17,16 +17,16 @@ class RottenTomatoesRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
-        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.TMDB].id = "550"
-        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="550",
+            url="https://www.themoviedb.org/movie/550",
+        )
         with open(
             os.path.join(TESTDATA_PATH, "rottentomatoes", "search_result.json"),
             encoding="UTF-8",
@@ -124,13 +124,12 @@ class RottenTomatoesRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="The Matrix", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/rottentomatoes/test_rottentomatoes_ratings_parser.py
+++ b/tests/unit/rottentomatoes/test_rottentomatoes_ratings_parser.py
@@ -3,6 +3,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.rottentomatoes.rottentomatoes_ratings_parser import (
     RottenTomatoesRatingsParser,
 )
@@ -45,19 +46,21 @@ class RottenTomatoesRatingsParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.ROTTENTOMATOES
         parser.site.site_name = "RottenTomatoes"
         parser.site.browser = browser_mock
 
         parser.parse()
 
         self.assertEqual(20, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Not My Day", parser.movies[0]["title"])
-        self.assertEqual(2014, parser.movies[0]["year"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ROTTENTOMATOES]))
+        self.assertEqual("Not My Day", parser.movies[0].title)
+        self.assertEqual(2014, parser.movies[0].year)
 
-        self.assertEqual("771362331", parser.movies[0]["rottentomatoes"]["id"])
+        self.assertEqual("771362331", parser.movies[0].site_data[Site.ROTTENTOMATOES].id)
         self.assertEqual(
             "https://rottentomatoes.com/m/not_my_day_2014",
-            parser.movies[0]["rottentomatoes"]["url"],
+            parser.movies[0].site_data[Site.ROTTENTOMATOES].url,
         )
-        self.assertEqual(8, parser.movies[0]["rottentomatoes"]["my_rating"])
+        self.assertEqual(8, parser.movies[0].site_data[Site.ROTTENTOMATOES].my_rating)

--- a/tests/unit/rottentomatoes/test_rottentomatoes_ratings_parser.py
+++ b/tests/unit/rottentomatoes/test_rottentomatoes_ratings_parser.py
@@ -54,11 +54,15 @@ class RottenTomatoesRatingsParserTest(TestCase):
 
         self.assertEqual(20, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ROTTENTOMATOES]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.ROTTENTOMATOES])
+        )
         self.assertEqual("Not My Day", parser.movies[0].title)
         self.assertEqual(2014, parser.movies[0].year)
 
-        self.assertEqual("771362331", parser.movies[0].site_data[Site.ROTTENTOMATOES].id)
+        self.assertEqual(
+            "771362331", parser.movies[0].site_data[Site.ROTTENTOMATOES].id
+        )
         self.assertEqual(
             "https://rottentomatoes.com/m/not_my_day_2014",
             parser.movies[0].site_data[Site.ROTTENTOMATOES].url,

--- a/tests/unit/tmdb/test_tmdb_ratings_inserter.py
+++ b/tests/unit/tmdb/test_tmdb_ratings_inserter.py
@@ -14,12 +14,12 @@ class TMDBRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie = Movie(title="Fight Club")
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
     @patch(
         "RatS.tmdb.tmdb_ratings_inserter.TMDBRatingsInserter._get_url_for_csv_upload"

--- a/tests/unit/tmdb/test_tmdb_ratings_inserter.py
+++ b/tests/unit/tmdb/test_tmdb_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site, SiteSpecificMovieData
 from RatS.tmdb.tmdb_ratings_inserter import TMDBRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -17,8 +18,8 @@ class TMDBRatingsInserterTest(TestCase):
         self.movie.title = "Fight Club"
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
 
     @patch(
         "RatS.tmdb.tmdb_ratings_inserter.TMDBRatingsInserter._get_url_for_csv_upload"
@@ -48,7 +49,7 @@ class TMDBRatingsInserterTest(TestCase):
         inserter.exports_folder = TESTDATA_PATH
         inserter.csv_filename = "converted.csv"
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(impex_mock.called)

--- a/tests/unit/tmdb/test_tmdb_ratings_inserter.py
+++ b/tests/unit/tmdb/test_tmdb_ratings_inserter.py
@@ -13,12 +13,12 @@ class TMDBRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
 
     @patch(
         "RatS.tmdb.tmdb_ratings_inserter.TMDBRatingsInserter._get_url_for_csv_upload"

--- a/tests/unit/tmdb/test_tmdb_ratings_parser.py
+++ b/tests/unit/tmdb/test_tmdb_ratings_parser.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Movie, Site
 from RatS.tmdb.tmdb_ratings_parser import TMDBRatingsParser
 
 TESTDATA_PATH = os.path.abspath(
@@ -37,6 +38,7 @@ class TMDBParserTest(TestCase):
         parser.args = False
         parser.movies = []
         parser.site = site_mock
+        parser.site.site = Site.TMDB
         parser.site.site_name = "TMDB"
         parser.site.browser = browser_mock
         parser.args = None
@@ -44,11 +46,12 @@ class TMDBParserTest(TestCase):
         parser.parse()
 
         self.assertEqual(50, len(parser.movies))
-        self.assertEqual(dict, type(parser.movies[0]))
-        self.assertEqual("Ghost in the Shell: The New Movie", parser.movies[0]["title"])
-        self.assertEqual(2017, parser.movies[0]["year"])
-        self.assertEqual("334376", parser.movies[0]["tmdb"]["id"])
+        self.assertEqual(Movie, type(parser.movies[0]))
+        parsed_movie: Movie = parser.movies[0]
+        self.assertEqual("Ghost in the Shell: The New Movie", parsed_movie.title)
+        self.assertEqual(2017, parsed_movie.year)
+        self.assertEqual("334376", parsed_movie.site_data[Site.TMDB].id)
         self.assertEqual(
-            "https://www.themoviedb.org/movie/334376", parser.movies[0]["tmdb"]["url"]
+            "https://www.themoviedb.org/movie/334376", parsed_movie.site_data[Site.TMDB].url
         )
-        self.assertEqual(6, parser.movies[0]["tmdb"]["my_rating"])
+        self.assertEqual(6, parsed_movie.site_data[Site.TMDB].my_rating)

--- a/tests/unit/tmdb/test_tmdb_ratings_parser.py
+++ b/tests/unit/tmdb/test_tmdb_ratings_parser.py
@@ -52,6 +52,7 @@ class TMDBParserTest(TestCase):
         self.assertEqual(2017, parsed_movie.year)
         self.assertEqual("334376", parsed_movie.site_data[Site.TMDB].id)
         self.assertEqual(
-            "https://www.themoviedb.org/movie/334376", parsed_movie.site_data[Site.TMDB].url
+            "https://www.themoviedb.org/movie/334376",
+            parsed_movie.site_data[Site.TMDB].url,
         )
         self.assertEqual(6, parsed_movie.site_data[Site.TMDB].my_rating)

--- a/tests/unit/trakt/test_trakt_ratings_inserter.py
+++ b/tests/unit/trakt/test_trakt_ratings_inserter.py
@@ -13,14 +13,14 @@ class TraktRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 9
-        self.movie["tmdb"] = dict()
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 9
+        self.movie["tmdb"] = SiteSpecificMovieData()
         self.movie["tmdb"]["id"] = "550"
         self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
         with open(
@@ -104,10 +104,10 @@ class TraktRatingsInserterTest(TestCase):
         inserter.site.site_name = "Trakt"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 10
@@ -148,10 +148,10 @@ class TraktRatingsInserterTest(TestCase):
         inserter.site.site_name = "Trakt"
         inserter.failed_movies = []
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Arrival"
         movie2["year"] = 2006
-        movie2["tmdb"] = dict()
+        movie2["tmdb"] = SiteSpecificMovieData()
         movie2["tmdb"]["id"] = "329865"
         movie2["tmdb"]["url"] = "https://www.themoviedb.org/movie/329865"
         movie2["tmdb"]["my_rating"] = 7
@@ -200,10 +200,10 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         compare_mock.return_value = True
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
-        movie2["tmdb"] = dict()
+        movie2["tmdb"] = SiteSpecificMovieData()
         movie2["tmdb"]["id"] = "550"
         movie2["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
         movie2["tmdb"]["my_rating"] = 9
@@ -229,7 +229,7 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         compare_mock.return_value = True
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Fight Club"
         movie2["year"] = 1999
 
@@ -264,10 +264,10 @@ class TraktRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1995
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0137523"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
         movie2["imdb"]["my_rating"] = 9

--- a/tests/unit/trakt/test_trakt_ratings_inserter.py
+++ b/tests/unit/trakt/test_trakt_ratings_inserter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+from RatS.base.movie_entity import Site, SiteSpecificMovieData, Movie
 from RatS.trakt.trakt_ratings_inserter import TraktRatingsInserter
 
 TESTDATA_PATH = os.path.abspath(
@@ -18,11 +19,11 @@ class TraktRatingsInserterTest(TestCase):
         self.movie.year = 1999
         self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
         self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB]["my_rating"] = 9
-        self.movie["tmdb"] = SiteSpecificMovieData()
-        self.movie["tmdb"]["id"] = "550"
-        self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
+        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB].my_rating = 9
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.TMDB].id = "550"
+        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
         with open(
             os.path.join(TESTDATA_PATH, "trakt", "search_result.html"), encoding="UTF-8"
         ) as search_results:
@@ -69,7 +70,7 @@ class TraktRatingsInserterTest(TestCase):
         inserter.site.site_name = "Trakt"
         inserter.failed_movies = []
 
-        inserter.insert([self.movie], "IMDB")
+        inserter.insert([self.movie], Site.IMDB)
 
         self.assertTrue(base_init_mock.called)
         self.assertTrue(progress_print_mock.called)
@@ -87,7 +88,7 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         result = inserter._compare_external_links(
-            self.movie_details_page, self.movie, "imdb.com", "imdb"
+            self.movie_details_page, self.movie, "imdb.com", Site.TMDB
         )  # pylint: disable=protected-access
 
         self.assertTrue(result)
@@ -105,15 +106,15 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 10
+        movie2.title = "Fight Club"
+        movie2.year = 1999
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 10
 
         result = inserter._compare_external_links(
-            self.movie_details_page, movie2, "imdb.com", "imdb"
+            self.movie_details_page, movie2, "imdb.com", Site.TMDB
         )  # pylint: disable=protected-access
 
         self.assertTrue(result)
@@ -131,7 +132,7 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         result = inserter._compare_external_links(
-            self.movie_details_page, self.movie, "themoviedb.org", "tmdb"
+            self.movie_details_page, self.movie, "themoviedb.org", Site.TMDB
         )  # pylint: disable=protected-access
 
         self.assertTrue(result)
@@ -149,15 +150,15 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         movie2 = Movie()
-        movie2["title"] = "Arrival"
-        movie2["year"] = 2006
-        movie2["tmdb"] = SiteSpecificMovieData()
-        movie2["tmdb"]["id"] = "329865"
-        movie2["tmdb"]["url"] = "https://www.themoviedb.org/movie/329865"
-        movie2["tmdb"]["my_rating"] = 7
+        movie2.title = "Arrival"
+        movie2.year = 2006
+        movie2.site_data[Site.TMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.TMDB].id = "329865"
+        movie2.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/329865"
+        movie2.site_data[Site.TMDB].my_rating = 7
 
         result = inserter._compare_external_links(
-            self.movie_details_page, movie2, "themoviedb.org", "tmdb"
+            self.movie_details_page, movie2, "themoviedb.org", Site.TMDB
         )  # pylint: disable=protected-access
 
         self.assertFalse(result)
@@ -201,12 +202,12 @@ class TraktRatingsInserterTest(TestCase):
         compare_mock.return_value = True
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
-        movie2["tmdb"] = SiteSpecificMovieData()
-        movie2["tmdb"]["id"] = "550"
-        movie2["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
-        movie2["tmdb"]["my_rating"] = 9
+        movie2.title = "Fight Club"
+        movie2.year = 1999
+        movie2.site_data[Site.TMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.TMDB].id = "550"
+        movie2.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
+        movie2.site_data[Site.TMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -230,8 +231,8 @@ class TraktRatingsInserterTest(TestCase):
         compare_mock.return_value = True
 
         movie2 = Movie()
-        movie2["title"] = "Fight Club"
-        movie2["year"] = 1999
+        movie2.title = "Fight Club"
+        movie2.year = 1999
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -265,12 +266,12 @@ class TraktRatingsInserterTest(TestCase):
         equality_mock.return_value = False
 
         movie2 = Movie()
-        movie2["title"] = "The Matrix"
-        movie2["year"] = 1995
-        movie2["imdb"] = SiteSpecificMovieData()
-        movie2["imdb"]["id"] = "tt0137523"
-        movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        movie2["imdb"]["my_rating"] = 9
+        movie2.title = "The Matrix"
+        movie2.year = 1995
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
+        movie2.site_data[Site.IMDB].id = "tt0137523"
+        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
+        movie2.site_data[Site.IMDB].my_rating = 9
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/trakt/test_trakt_ratings_inserter.py
+++ b/tests/unit/trakt/test_trakt_ratings_inserter.py
@@ -88,7 +88,7 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
 
         result = inserter._compare_external_links(
-            self.movie_details_page, self.movie, "imdb.com", Site.TMDB
+            self.movie_details_page, self.movie, "imdb.com", Site.IMDB
         )  # pylint: disable=protected-access
 
         self.assertTrue(result)
@@ -113,7 +113,7 @@ class TraktRatingsInserterTest(TestCase):
         )
 
         result = inserter._compare_external_links(
-            self.movie_details_page, movie2, "imdb.com", Site.TMDB
+            self.movie_details_page, movie2, "imdb.com", Site.IMDB
         )  # pylint: disable=protected-access
 
         self.assertTrue(result)

--- a/tests/unit/trakt/test_trakt_ratings_inserter.py
+++ b/tests/unit/trakt/test_trakt_ratings_inserter.py
@@ -14,16 +14,16 @@ class TraktRatingsInserterTest(TestCase):
     def setUp(self):
         if not os.path.exists(os.path.join(TESTDATA_PATH, "exports")):
             os.makedirs(os.path.join(TESTDATA_PATH, "exports"))
-        self.movie = Movie()
-        self.movie.title = "Fight Club"
-        self.movie.year = 1999
-        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.IMDB].id = "tt0137523"
-        self.movie.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        self.movie.site_data[Site.IMDB].my_rating = 9
-        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData()
-        self.movie.site_data[Site.TMDB].id = "550"
-        self.movie.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
+        self.movie = Movie(title="Fight Club", year=1999)
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
+        self.movie.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="550",
+            url="https://www.themoviedb.org/movie/550",
+        )
         with open(
             os.path.join(TESTDATA_PATH, "trakt", "search_result.html"), encoding="UTF-8"
         ) as search_results:
@@ -105,13 +105,12 @@ class TraktRatingsInserterTest(TestCase):
         inserter.site.site_name = "Trakt"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 10
+        movie2 = Movie(title="Fight Club", year=1999)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=10,
+        )
 
         result = inserter._compare_external_links(
             self.movie_details_page, movie2, "imdb.com", Site.TMDB
@@ -149,13 +148,12 @@ class TraktRatingsInserterTest(TestCase):
         inserter.site.site_name = "Trakt"
         inserter.failed_movies = []
 
-        movie2 = Movie()
-        movie2.title = "Arrival"
-        movie2.year = 2006
-        movie2.site_data[Site.TMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.TMDB].id = "329865"
-        movie2.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/329865"
-        movie2.site_data[Site.TMDB].my_rating = 7
+        movie2 = Movie(title="Arrival", year=2006)
+        movie2.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="329865",
+            url="https://www.themoviedb.org/movie/329865",
+            my_rating=7,
+        )
 
         result = inserter._compare_external_links(
             self.movie_details_page, movie2, "themoviedb.org", Site.TMDB
@@ -201,13 +199,12 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         compare_mock.return_value = True
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
-        movie2.site_data[Site.TMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.TMDB].id = "550"
-        movie2.site_data[Site.TMDB].url = "https://www.themoviedb.org/movie/550"
-        movie2.site_data[Site.TMDB].my_rating = 9
+        movie2 = Movie(title="Fight Club", year=1999)
+        movie2.site_data[Site.TMDB] = SiteSpecificMovieData(
+            id="550",
+            url="https://www.themoviedb.org/movie/550",
+            my_rating=9,
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -230,9 +227,7 @@ class TraktRatingsInserterTest(TestCase):
         inserter.failed_movies = []
         compare_mock.return_value = True
 
-        movie2 = Movie()
-        movie2.title = "Fight Club"
-        movie2.year = 1999
+        movie2 = Movie(title="Fight Club", year=1999)
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 
@@ -265,13 +260,12 @@ class TraktRatingsInserterTest(TestCase):
         tiles_mock.return_value = self.search_result_tile_list
         equality_mock.return_value = False
 
-        movie2 = Movie()
-        movie2.title = "The Matrix"
-        movie2.year = 1995
-        movie2.site_data[Site.IMDB] = SiteSpecificMovieData()
-        movie2.site_data[Site.IMDB].id = "tt0137523"
-        movie2.site_data[Site.IMDB].url = "https://www.imdb.com/title/tt0137523"
-        movie2.site_data[Site.IMDB].my_rating = 9
+        movie2 = Movie(title="The Matrix", year=1995)
+        movie2.site_data[Site.IMDB] = SiteSpecificMovieData(
+            id="tt0137523",
+            url="https://www.imdb.com/title/tt0137523",
+            my_rating=9,
+        )
 
         result = inserter._find_movie(movie2)  # pylint: disable=protected-access
 

--- a/tests/unit/trakt/test_trakt_ratings_parser.py
+++ b/tests/unit/trakt/test_trakt_ratings_parser.py
@@ -121,8 +121,8 @@ class TraktRatingsParserTest(TestCase):
 
         # Top Gear Patagonia
         self.assertEqual(2014, movie.year)
-        self.assertNotIn(Site.IMDB, movie.site_data)
-        self.assertIn(Site.TMDB, movie.site_data)
+        self.assertNotIn(Site.IMDB, movie.site_data.keys())
+        self.assertIn(Site.TMDB, movie.site_data.keys())
         self.assertEqual("314390", movie.site_data[Site.TMDB].id)
         self.assertEqual(
             "https://www.themoviedb.org/movie/314390", movie.site_data[Site.TMDB].url

--- a/tests/unit/trakt/test_trakt_ratings_parser.py
+++ b/tests/unit/trakt/test_trakt_ratings_parser.py
@@ -68,11 +68,14 @@ class TraktRatingsParserTest(TestCase):
         self.assertEqual(60, parse_movie_mock.call_count)
         self.assertEqual(60, len(parser.movies))
         self.assertEqual(Movie, type(parser.movies[0]))
-        self.assertEqual(SiteSpecificMovieData, type(parser.movies[0].site_data[Site.TRAKT]))
+        self.assertEqual(
+            SiteSpecificMovieData, type(parser.movies[0].site_data[Site.TRAKT])
+        )
         self.assertEqual("Arrival", parser.movies[0].title)
         self.assertEqual("210803", parser.movies[0].site_data[Site.TRAKT].id)
         self.assertEqual(
-            "https://trakt.tv/movies/arrival-2016", parser.movies[0].site_data[Site.TRAKT].url
+            "https://trakt.tv/movies/arrival-2016",
+            parser.movies[0].site_data[Site.TRAKT].url,
         )
 
     @patch("RatS.utils.browser_handler.Firefox")
@@ -87,7 +90,7 @@ class TraktRatingsParserTest(TestCase):
         parser.site.site_name = "Trakt"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
-        movie = Movie()
+        movie = Movie(title="doesn't matter right now")
 
         parser.parse_movie_details_page(movie)
 
@@ -98,7 +101,9 @@ class TraktRatingsParserTest(TestCase):
             "https://www.imdb.com/title/tt0137523", movie.site_data[Site.IMDB].url
         )
         self.assertEqual("550", movie.site_data[Site.TMDB].id)
-        self.assertEqual("https://www.themoviedb.org/movie/550", movie.site_data[Site.TMDB].url)
+        self.assertEqual(
+            "https://www.themoviedb.org/movie/550", movie.site_data[Site.TMDB].url
+        )
         self.assertEqual(10, int(movie.site_data[Site.TRAKT].my_rating))
 
     @patch("RatS.utils.browser_handler.Firefox")
@@ -115,7 +120,7 @@ class TraktRatingsParserTest(TestCase):
         parser.site.site_name = "Trakt"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page_without_imdb_id
-        movie = Movie()
+        movie = Movie(title="doesn't matter right now")
 
         parser.parse_movie_details_page(movie)
 

--- a/tests/unit/trakt/test_trakt_ratings_parser.py
+++ b/tests/unit/trakt/test_trakt_ratings_parser.py
@@ -83,14 +83,16 @@ class TraktRatingsParserTest(TestCase):
         parser.site.site_name = "Trakt"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page
-        movie = dict()
+        movie = Movie()
 
         parser.parse_movie_details_page(movie)
 
         # Fight Club
-        self.assertEqual(1999, movie["year"])
-        self.assertEqual("tt0137523", movie["imdb"]["id"])
-        self.assertEqual("https://www.imdb.com/title/tt0137523", movie["imdb"]["url"])
+        self.assertEqual(1999, movie.year)
+        self.assertEqual("tt0137523", movie.site_data[Site.IMDB].id)
+        self.assertEqual(
+            "https://www.imdb.com/title/tt0137523", movie.site_data[Site.IMDB]["url"]
+        )
         self.assertEqual("550", movie["tmdb"]["id"])
         self.assertEqual("https://www.themoviedb.org/movie/550", movie["tmdb"]["url"])
         self.assertEqual(10, movie["trakt"]["my_rating"])
@@ -108,12 +110,12 @@ class TraktRatingsParserTest(TestCase):
         parser.site.site_name = "Trakt"
         parser.site.browser = browser_mock
         browser_mock.page_source = self.detail_page_without_imdb_id
-        movie = dict()
+        movie = Movie()
 
         parser.parse_movie_details_page(movie)
 
         # Top Gear Patagonia
-        self.assertEqual(2014, movie["year"])
+        self.assertEqual(2014, movie.year)
         self.assertNotIn("imdb", movie)
         self.assertEqual("314390", movie["tmdb"]["id"])
         self.assertEqual(

--- a/tests/unit/utils/test_file_impex.py
+++ b/tests/unit/utils/test_file_impex.py
@@ -19,18 +19,18 @@ TESTDATA_NEW_PATH = os.path.abspath(
 
 class FileHandlerTest(TestCase):
     def setUp(self):
-        self.movie = dict()
-        self.movie["title"] = "Fight Club"
-        self.movie["year"] = 1999
-        self.movie["imdb"] = dict()
-        self.movie["imdb"]["id"] = "tt0137523"
-        self.movie["imdb"]["url"] = "https://www.imdb.com/title/tt0137523"
-        self.movie["imdb"]["my_rating"] = 10
-        self.movie["trakt"] = dict()
+        self.movie = Movie()
+        self.movie.title = "Fight Club"
+        self.movie.year = 1999
+        self.movie.site_data[Site.IMDB] = SiteSpecificMovieData()
+        self.movie.site_data[Site.IMDB].id = "tt0137523"
+        self.movie.site_data[Site.IMDB]["url"] = "https://www.imdb.com/title/tt0137523"
+        self.movie.site_data[Site.IMDB]["my_rating"] = 10
+        self.movie["trakt"] = SiteSpecificMovieData()
         self.movie["trakt"]["id"] = "432"
         self.movie["trakt"]["url"] = "https://trakt.tv/movies/fight-club-1999"
         self.movie["trakt"]["my_rating"] = 10
-        self.movie["tmdb"] = dict()
+        self.movie["tmdb"] = SiteSpecificMovieData()
         self.movie["tmdb"]["id"] = "550"
         self.movie["tmdb"]["url"] = "https://www.themoviedb.org/movie/550"
 
@@ -80,13 +80,13 @@ class FileHandlerTest(TestCase):
         os.remove(filename)
 
     def test_save_multiple_movies_to_json(self):
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "The Matrix"
         movie2["year"] = 1999
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0133093"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0133093"
-        movie2["trakt"] = dict()
+        movie2["trakt"] = SiteSpecificMovieData()
         movie2["trakt"]["id"] = "481"
         movie2["trakt"]["url"] = "https://trakt.tv/movies/the-matrix-1999"
         movie2["trakt"]["my_rating"] = 9
@@ -133,23 +133,28 @@ class FileHandlerTest(TestCase):
             reader = csv.reader(file, delimiter=",")
             headers = next(reader)
             row = next(reader)
-            self.assertEqual(self.movie["title"], row[headers.index("Title")])
-            self.assertEqual(self.movie["year"], int(row[headers.index("Year")]))
-            self.assertEqual(self.movie["imdb"]["id"], row[headers.index("Const")])
-            self.assertEqual(self.movie["imdb"]["url"], row[headers.index("URL")])
+            self.assertEqual(self.movie.title, row[headers.index("Title")])
+            self.assertEqual(self.movie.year, int(row[headers.index("Year")]))
             self.assertEqual(
-                self.movie["imdb"]["my_rating"], int(row[headers.index("Your Rating")])
+                self.movie.site_data[Site.IMDB].id, row[headers.index("Const")]
+            )
+            self.assertEqual(
+                self.movie.site_data[Site.IMDB]["url"], row[headers.index("URL")]
+            )
+            self.assertEqual(
+                self.movie.site_data[Site.IMDB]["my_rating"],
+                int(row[headers.index("Your Rating")]),
             )
         os.remove(filename)
 
     def test_save_multiple_movies_to_csv(self):
-        movie2 = dict()
+        movie2 = Movie()
         movie2["title"] = "Star Trek - Der Film"
         movie2["year"] = 1979
-        movie2["imdb"] = dict()
+        movie2["imdb"] = SiteSpecificMovieData()
         movie2["imdb"]["id"] = "tt0079945"
         movie2["imdb"]["url"] = "https://www.imdb.com/title/tt0079945"
-        movie2["trakt"] = dict()
+        movie2["trakt"] = SiteSpecificMovieData()
         movie2["trakt"]["id"] = "117"
         movie2["trakt"][
             "url"
@@ -170,10 +175,14 @@ class FileHandlerTest(TestCase):
             reader = csv.reader(file, delimiter=",")
             headers = next(reader)  # csv header
             row1 = next(reader)
-            self.assertEqual(self.movie["title"], row1[headers.index("Title")])
-            self.assertEqual(self.movie["year"], int(row1[headers.index("Year")]))
-            self.assertEqual(self.movie["imdb"]["id"], row1[headers.index("Const")])
-            self.assertEqual(self.movie["imdb"]["url"], row1[headers.index("URL")])
+            self.assertEqual(self.movie.title, row1[headers.index("Title")])
+            self.assertEqual(self.movie.year, int(row1[headers.index("Year")]))
+            self.assertEqual(
+                self.movie.site_data[Site.IMDB].id, row1[headers.index("Const")]
+            )
+            self.assertEqual(
+                self.movie.site_data[Site.IMDB]["url"], row1[headers.index("URL")]
+            )
             self.assertEqual(
                 self.movie["trakt"]["my_rating"],
                 int(row1[headers.index("Your Rating")]),

--- a/tests/unit/utils/test_file_impex.py
+++ b/tests/unit/utils/test_file_impex.py
@@ -36,8 +36,9 @@ class FileHandlerTest(TestCase):
         )
 
     def test_load_movies_from_json(self):
-        movies = file_impex.load_movies_from_json(
-            folder=os.path.join(TESTDATA_PATH, "trakt"), filename="exports.json"
+        movies: List[Movie] = file_impex.load_movies_from_json(
+            folder=os.path.join(TESTDATA_PATH, "trakt"),
+            filename="exports.json",
         )
         self.assertEqual(1, len(movies))
         self.assertEqual(list, type(movies))

--- a/tests/unit/utils/test_file_impex.py
+++ b/tests/unit/utils/test_file_impex.py
@@ -46,14 +46,24 @@ class FileHandlerTest(TestCase):
         self.assertEqual("Fight Club", movies[0].title)
         self.assertEqual(1999, movies[0].year)
 
-        self.assertEqual(SiteSpecificMovieData, type(movies[0].site_data.get(Site.IMDB)))
+        self.assertEqual(
+            SiteSpecificMovieData, type(movies[0].site_data.get(Site.IMDB))
+        )
         self.assertEqual("tt0137523", movies[0].site_data.get(Site.IMDB).id)
-        self.assertEqual("https://www.imdb.com/title/tt0137523/", movies[0].site_data.get(Site.IMDB).url)
+        self.assertEqual(
+            "https://www.imdb.com/title/tt0137523/",
+            movies[0].site_data.get(Site.IMDB).url,
+        )
         self.assertEqual(10, movies[0].site_data.get(Site.IMDB).my_rating)
 
-        self.assertEqual(SiteSpecificMovieData, type(movies[0].site_data.get(Site.TRAKT)))
+        self.assertEqual(
+            SiteSpecificMovieData, type(movies[0].site_data.get(Site.TRAKT))
+        )
         self.assertEqual("432", movies[0].site_data.get(Site.TRAKT).id)
-        self.assertEqual("https://trakt.tv/movies/fight-club-1999", movies[0].site_data.get(Site.TRAKT).url)
+        self.assertEqual(
+            "https://trakt.tv/movies/fight-club-1999",
+            movies[0].site_data.get(Site.TRAKT).url,
+        )
         self.assertEqual(10, movies[0].site_data.get(Site.TRAKT).my_rating)
 
     def test_save_empty_movies_to_json(self):

--- a/tests/unit/utils/test_file_impex.py
+++ b/tests/unit/utils/test_file_impex.py
@@ -44,6 +44,17 @@ class FileHandlerTest(TestCase):
         self.assertEqual(list, type(movies))
         self.assertEqual(Movie, type(movies[0]))
         self.assertEqual("Fight Club", movies[0].title)
+        self.assertEqual(1999, movies[0].year)
+
+        self.assertEqual(SiteSpecificMovieData, type(movies[0].site_data.get(Site.IMDB)))
+        self.assertEqual("tt0137523", movies[0].site_data.get(Site.IMDB).id)
+        self.assertEqual("https://www.imdb.com/title/tt0137523/", movies[0].site_data.get(Site.IMDB).url)
+        self.assertEqual(10, movies[0].site_data.get(Site.IMDB).my_rating)
+
+        self.assertEqual(SiteSpecificMovieData, type(movies[0].site_data.get(Site.TRAKT)))
+        self.assertEqual("432", movies[0].site_data.get(Site.TRAKT).id)
+        self.assertEqual("https://trakt.tv/movies/fight-club-1999", movies[0].site_data.get(Site.TRAKT).url)
+        self.assertEqual(10, movies[0].site_data.get(Site.TRAKT).my_rating)
 
     def test_save_empty_movies_to_json(self):
         movies = []

--- a/transfer_ratings.py
+++ b/transfer_ratings.py
@@ -12,7 +12,11 @@ from RatS.allocine.allocine_ratings_parser import AlloCineRatingsParser
 from RatS.base.base_ratings_inserter import RatingsInserter
 from RatS.base.base_ratings_parser import RatingsParser
 from RatS.base.movie_entity import Site, Movie
-from RatS.base.base_exceptions import RatSException, NoMoviesForInsertion, NoValidCredentialsException
+from RatS.base.base_exceptions import (
+    RatSException,
+    NoMoviesForInsertion,
+    NoValidCredentialsException,
+)
 from RatS.criticker.criticker_ratings_inserter import CritickerRatingsInserter
 from RatS.criticker.criticker_ratings_parser import CritickerRatingsParser
 from RatS.filmaffinity.filmaffinity_ratings_inserter import FilmAffinityRatingsInserter

--- a/transfer_ratings.py
+++ b/transfer_ratings.py
@@ -5,9 +5,13 @@ import os
 import sys
 import time
 import traceback
+from typing import Mapping, List
 
 from RatS.allocine.allocine_ratings_inserter import AlloCineRatingsInserter
 from RatS.allocine.allocine_ratings_parser import AlloCineRatingsParser
+from RatS.base.base_ratings_inserter import RatingsInserter
+from RatS.base.base_ratings_parser import RatingsParser
+from RatS.base.movie_entity import Site, Movie
 from RatS.base.no_movies_for_insertion import NoMoviesForInsertion
 from RatS.base.no_valid_credentials_exception import NoValidCredentialsException
 from RatS.base.rats_exception import RatSException
@@ -49,40 +53,40 @@ EXPORTS_FOLDER = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "RatS", "exports")
 )
 
-PARSERS = {
-    "ALLOCINE": AlloCineRatingsParser,
-    "CRITICKER": CritickerRatingsParser,
-    "FILMAFFINITY": FilmAffinityRatingsParser,
-    "FILMTIPSET": FilmtipsetRatingsParser,
-    # 'FLIXSTER': FlixsterRatingsParser,
-    "ICHECKMOVIES": ICheckMoviesRatingsParser,
-    "IMDB": IMDBRatingsParser,
-    "LETTERBOXD": LetterboxdRatingsParser,
-    "LISTAL": ListalRatingsParser,
-    "MOVIELENS": MovielensRatingsParser,
-    "MOVIEPILOT": MoviePilotRatingsParser,
-    "PLEX": PlexRatingsParser,
-    "ROTTENTOMATOES": RottenTomatoesRatingsParser,
-    "TMDB": TMDBRatingsParser,
-    "TRAKT": TraktRatingsParser,
+PARSERS: Mapping[Site, type] = {
+    Site.ALLOCINE: AlloCineRatingsParser,
+    Site.CRITICKER: CritickerRatingsParser,
+    Site.FILMAFFINITY: FilmAffinityRatingsParser,
+    Site.FILMTIPSET: FilmtipsetRatingsParser,
+    # Site.FLIXSTER: FlixsterRatingsParser,
+    Site.ICHECKMOVIES: ICheckMoviesRatingsParser,
+    Site.IMDB: IMDBRatingsParser,
+    Site.LETTERBOXD: LetterboxdRatingsParser,
+    Site.LISTAL: ListalRatingsParser,
+    Site.MOVIELENS: MovielensRatingsParser,
+    Site.MOVIEPILOT: MoviePilotRatingsParser,
+    Site.PLEX: PlexRatingsParser,
+    Site.ROTTENTOMATOES: RottenTomatoesRatingsParser,
+    Site.TMDB: TMDBRatingsParser,
+    Site.TRAKT: TraktRatingsParser,
 }
-INSERTERS = {
-    "ALLOCINE": AlloCineRatingsInserter,
-    "CRITICKER": CritickerRatingsInserter,
-    "FILMAFFINITY": FilmAffinityRatingsInserter,
-    "FILMTIPSET": FilmtipsetRatingsInserter,
-    # 'FLIXSTER': FlixsterRatingsInserter,
-    "ICHECKMOVIES": ICheckMoviesRatingsInserter,
-    "IMDB": IMDBRatingsInserter,
-    "LETTERBOXD": LetterboxdRatingsInserter,
-    "LISTAL": ListalRatingsInserter,
-    "METACRITIC": MetacriticRatingsInserter,
-    "MOVIELENS": MovielensRatingsInserter,
-    "MOVIEPILOT": MoviePilotRatingsInserter,
-    "PLEX": PlexRatingsInserter,
-    "ROTTENTOMATOES": RottenTomatoesRatingsInserter,
-    "TMDB": TMDBRatingsInserter,
-    "TRAKT": TraktRatingsInserter,
+INSERTERS: Mapping[Site, type] = {
+    Site.ALLOCINE: AlloCineRatingsInserter,
+    Site.CRITICKER: CritickerRatingsInserter,
+    Site.FILMAFFINITY: FilmAffinityRatingsInserter,
+    Site.FILMTIPSET: FilmtipsetRatingsInserter,
+    # Site.FLIXSTER: FlixsterRatingsInserter,
+    Site.ICHECKMOVIES: ICheckMoviesRatingsInserter,
+    Site.IMDB: IMDBRatingsInserter,
+    Site.LETTERBOXD: LetterboxdRatingsInserter,
+    Site.LISTAL: ListalRatingsInserter,
+    Site.METACRITIC: MetacriticRatingsInserter,
+    Site.MOVIELENS: MovielensRatingsInserter,
+    Site.MOVIEPILOT: MoviePilotRatingsInserter,
+    Site.PLEX: PlexRatingsInserter,
+    Site.ROTTENTOMATOES: RottenTomatoesRatingsInserter,
+    Site.TMDB: TMDBRatingsInserter,
+    Site.TRAKT: TraktRatingsInserter,
 }
 
 
@@ -139,10 +143,10 @@ def parse_args():
     return args
 
 
-def get_parser_from_arg(param):
+def get_parser_from_arg(param: str) -> type:  # TODO make the argument a Site and the return type a RatingsParser
     try:
-        return PARSERS[param.upper()]
-    except KeyError:
+        return PARSERS.get(Site(param.upper()))
+    except (KeyError, ValueError):
         command_line.error(f"No parser matching '{param}' found.")
         sys.stdout.write("Available parsers:\r\n")
         for parser in PARSERS:
@@ -151,10 +155,10 @@ def get_parser_from_arg(param):
         sys.exit(1)
 
 
-def get_inserter_from_arg(param):
+def get_inserter_from_arg(param: str) -> type:  # TODO make the argument a Site and the return type a RatingsInserter
     try:
-        return INSERTERS[param.upper()]
-    except KeyError:
+        return INSERTERS.get(Site(param.upper()))
+    except (KeyError, ValueError):
         command_line.error(f"No inserter matching '{param}' found.")
         sys.stdout.write("Available inserters:\r\n")
         for inserter in INSERTERS:
@@ -165,18 +169,18 @@ def get_inserter_from_arg(param):
 
 def execute(args):
     try:
-        parser = get_parser_from_arg(args.source)(args)
-        movies = execute_parsing(args, parser)
+        parser: RatingsParser = get_parser_from_arg(args.source)(args)
+        movies: List[Movie] = execute_parsing(args, parser)
         execute_inserting(args, movies, parser)
     except RatSException as e:
         command_line.error(str(e))
 
 
-def execute_inserting(args, movies, parser):
+def execute_inserting(args, movies: List[Movie], parser: RatingsParser):
     if not args.all_destinations and not args.destination:
         return
-    destinations = (
-        list(INSERTERS.keys())
+    destinations: List[str] = (  # TODO make this a List[Site]
+        [inserter.name for inserter in INSERTERS.keys()]
         if args.all_destinations
         else [destination.upper() for destination in args.destination]
     )
@@ -189,13 +193,13 @@ def execute_inserting(args, movies, parser):
         # INSERT THE DATA
         for destination in destinations:
             try:
-                inserter = get_inserter_from_arg(destination)(args)
+                inserter: RatingsInserter = get_inserter_from_arg(destination)(args)
                 insert_movie_ratings(inserter, movies, type(parser.site).__name__)
             except RatSException as e:
                 command_line.error(str(e))
 
 
-def _filter_source_site_from_destinations(destinations, parser_site_name):
+def _filter_source_site_from_destinations(destinations: List[str], parser_site_name: str):
     if parser_site_name.upper() in destinations:
         destinations.remove(parser_site_name.upper())
         command_line.info(
@@ -203,29 +207,29 @@ def _filter_source_site_from_destinations(destinations, parser_site_name):
         )
 
 
-def execute_parsing(args, parser):
+def execute_parsing(args, parser: RatingsParser) -> List[Movie]:
     if not parser.site.CREDENTIALS_VALID:
         raise NoValidCredentialsException(
             f"No valid credentials found for {parser.site.site_name}. Skipping parsing."
         )
     if args.file:
         # LOAD FROM FILE
-        movies = load_data_from_file(args.file)
+        movies: List[Movie] = load_data_from_file(args.file)
         parser.site.browser_handler.kill()
     else:
         # PARSE DATA
-        movies = parse_data_from_source(parser)
+        movies: List[Movie] = parse_data_from_source(parser)
     return movies
 
 
-def parse_data_from_source(parser):
+def parse_data_from_source(parser: RatingsParser) -> List[Movie]:
     try:
-        movies = parser.parse()
+        movies: List[Movie] = parser.parse()
     except RatSException as e:
         command_line.error(str(e))
         sys.exit(1)
 
-    json_filename = f"{TIMESTAMP}_{type(parser.site).__name__}.json"
+    json_filename: str = f"{TIMESTAMP}_{type(parser.site).__name__}.json"
     file_impex.save_movies_to_json(
         movies, folder=EXPORTS_FOLDER, filename=json_filename
     )
@@ -237,8 +241,8 @@ def parse_data_from_source(parser):
     return movies
 
 
-def load_data_from_file(filename):
-    movies = file_impex.load_movies_from_json(folder=EXPORTS_FOLDER, filename=filename)
+def load_data_from_file(filename: str) -> List[Movie]:
+    movies: List[Movie] = file_impex.load_movies_from_json(folder=EXPORTS_FOLDER, filename=filename)
     sys.stdout.write(
         f"\r\n===== loaded {len(movies)} movies from {EXPORTS_FOLDER}/{filename}\r\n"
     )
@@ -246,7 +250,7 @@ def load_data_from_file(filename):
     return movies
 
 
-def insert_movie_ratings(inserter, movies, source):
+def insert_movie_ratings(inserter: RatingsInserter, movies: List[Movie], source: str):
     if inserter.site.CREDENTIALS_VALID:
         try:
             inserter.insert(movies, source)

--- a/transfer_ratings.py
+++ b/transfer_ratings.py
@@ -12,11 +12,7 @@ from RatS.allocine.allocine_ratings_parser import AlloCineRatingsParser
 from RatS.base.base_ratings_inserter import RatingsInserter
 from RatS.base.base_ratings_parser import RatingsParser
 from RatS.base.movie_entity import Site, Movie
-from RatS.base.no_movies_for_insertion import NoMoviesForInsertion
-from RatS.base.exceptions.no_valid_credentials_exception import (
-    NoValidCredentialsException,
-)
-from RatS.base.base_exceptions import RatSException
+from RatS.base.base_exceptions import RatSException, NoMoviesForInsertion, NoValidCredentialsException
 from RatS.criticker.criticker_ratings_inserter import CritickerRatingsInserter
 from RatS.criticker.criticker_ratings_parser import CritickerRatingsParser
 from RatS.filmaffinity.filmaffinity_ratings_inserter import FilmAffinityRatingsInserter

--- a/transfer_ratings.py
+++ b/transfer_ratings.py
@@ -147,7 +147,7 @@ def parse_args():
 
 def get_parser_from_arg(
     param: str,
-) -> type:  # TODO make the argument a Site and the return type a RatingsParser
+) -> type:  # TODO #170 - make the argument a Site and the return type a RatingsParser
     try:
         return PARSERS.get(Site(param.upper()))
     except (KeyError, ValueError):
@@ -161,7 +161,7 @@ def get_parser_from_arg(
 
 def get_inserter_from_arg(
     param: str,
-) -> type:  # TODO make the argument a Site and the return type a RatingsInserter
+) -> type:  # TODO #170 - make the argument a Site and the return type a RatingsInserter
     try:
         return INSERTERS.get(Site(param.upper()))
     except (KeyError, ValueError):
@@ -185,7 +185,7 @@ def execute(args):
 def execute_inserting(args, movies: List[Movie], parser: RatingsParser):
     if not args.all_destinations and not args.destination:
         return
-    destinations: List[str] = (  # TODO make this a List[Site]
+    destinations: List[str] = (  # TODO #170 - make this a List[Site]
         [inserter.name for inserter in INSERTERS.keys()]
         if args.all_destinations
         else [destination.upper() for destination in args.destination]


### PR DESCRIPTION
### Type of Change
Refactoring, code improvement

### Issue or RFC
 #170

### Description of the Change
- Re-Introduction of a `Movie` data class
- Use type-hinting for `Movie`, `str`, `int`, `List` where possible

### Current challenges
- After importing data from a json or csv, the data has type `dict` (or rather `List(dict)`) instead of `Movie`. This makes one specific unit test fail, but also causes the import of data for insertion to fail. There are `#TODO` comments in the code where this applies.
